### PR TITLE
feat: Add API Client with minimal routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,74 @@
 # here-go
 
-HERE Go API Client
+here-go is a Go client library for accessing the HERE APIs
+
+API docs can be found [here](https://developer.here.com/documentation/)
+
+## Usage
+
+```go
+import "github.com/einride/here-go/pkg/here"
+```
+
+Construct a new HERE client, then use the various services on the client to
+access different parts of the HERE API. For example:
+
+```go
+httpClient := here.NewAPIKeyHTTPClient(".... your api key ...")
+client := here.NewClient(httpClient)
+
+// Get routes from Einride Gothenburg to Einride Stockholm
+json, err := client.Routing.Get(context.Background(), here.RoutingRequest{
+    TransportMode: here.TransportModeCar,
+    Origin: here.Waypoint{
+        Place: here.LatLong{
+            Lat:  57.707746,
+            Long: 11.9475834,
+        },
+    },
+    Destination: here.Waypoint{
+        Place: here.LatLong{
+            Lat:  58.5177323,
+            Long: 13.8859,
+        },
+    },
+})
+```
+
+### Authentication
+
+The here-go library does not directly handle authentication. Instead, when
+creating a new client, pass an `http.Client` that can handle authentication for
+you. The easiest and recommended way to do this is using the [oauth2][]
+library, but you can always use any other library that provides an
+`http.Client`. If you have an OAuth2 access token (for example, a [personal
+API token][]), you can use it with the oauth2 library using:
+
+```go
+import "golang.org/x/oauth2"
+
+func main() {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: "... your access token ..."},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := here.NewClient(tc)
+}
+```
+
+Note that when using an authenticated Client, all calls made by the client will
+include the specified OAuth token. Therefore, authenticated clients should
+almost never be shared between different users.
+
+See the [oauth2 docs][] for complete instructions on using that library.
+
+If you wish to use an API Key, use the APIKey client
+
+```go
+func main() {
+	httpClient := here.NewAPIKeyHTTPClient(".... your api key ...")
+	client := here.New(httpClient)
+}
+```

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: gcr.io/einride/cloud-builder
+    args: ["/cloud-builder/git-init.sh"]
+    env:
+      - 'COMMIT_SHA=$COMMIT_SHA'
+      - 'REPO_NAME=$REPO_NAME'
+  
+  - name: gcr.io/einride/cloud-builder
+    args: ["make"]

--- a/pkg/here/apikey.go
+++ b/pkg/here/apikey.go
@@ -1,0 +1,31 @@
+package here
+
+import (
+	"net/http"
+)
+
+type apiKeyRoundTripper struct {
+	apiKey string
+	next   http.RoundTripper
+}
+
+// NewAPIKeyHTTPClient returns an HTTP Client which uses the given API Key.
+// If next is nil http.DefaultTransport is used.
+func NewAPIKeyHTTPClient(key string, next http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: &apiKeyRoundTripper{
+			apiKey: key,
+			next:   next,
+		},
+	}
+}
+
+func (r *apiKeyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	vals := req.URL.Query()
+	vals.Set("apiKey", r.apiKey)
+	req.URL.RawQuery = vals.Encode()
+	if r.next != nil {
+		return r.next.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/pkg/here/here.go
+++ b/pkg/here/here.go
@@ -1,1 +1,139 @@
 package here
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	userAgent = "einride/here-go"
+)
+
+type Client struct {
+	client *http.Client // HTTP client used to communicate with the API.
+
+	UserAgent string
+
+	common service // Reuse a single struct instead of allocating one for each service on the heap.
+
+	// Services used for talking to different parts of the HERE API
+	Routing *RoutingService
+}
+
+type service struct {
+	// URL for service API requests
+	URL    *url.URL
+	client *Client
+}
+
+// An ErrorResponse reports the error caused by an API request.
+type ErrorResponse struct {
+	// HTTP response that caused this error
+	Response *http.Response
+}
+
+func (r *ErrorResponse) Error() string {
+	return fmt.Sprintf("%v %v: %d",
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode)
+}
+
+// New returns a new HERE API client. If a nil httpClient is
+// provided, a new http.Client will be used. To use API methods which require
+// authentication, provide an http.Client that will perform the authentication
+// for you (such as that provided by the golang.org/x/oauth2 library).
+func New(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	c := &Client{client: httpClient, UserAgent: userAgent}
+	c.common.client = c
+	rURL, _ := url.Parse("https://router.hereapi.com/v8/")
+	c.Routing = &RoutingService{URL: rURL, client: c}
+	return c
+}
+
+// NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
+// BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
+// value pointed to by body is JSON encoded and included in as the request body.
+// A raw query string can be specified by rawQuery.
+func (c *Client) NewRequest(
+	ctx context.Context,
+	u *url.URL,
+	method, rawQuery string,
+	body interface{},
+) (*http.Request, error) {
+	if len(rawQuery) > 0 {
+		u.RawQuery = rawQuery
+	}
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// req.Header.Set("Accept", mediaTypeV3)
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	return req, nil
+}
+
+// Do sends an API request and returns the API response. The API response is JSON decoded and stored in the value
+// pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
+// the raw response will be written to v, without attempting to decode it.
+func (c *Client) Do(req *http.Request, v interface{}) error {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if rerr := resp.Body.Close(); err == nil {
+			err = rerr
+		}
+	}()
+	err = CheckResponse(resp)
+	if err != nil {
+		return err
+	}
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, err = io.Copy(w, resp.Body)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(v)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// CheckResponse checks the API response for errors, and returns them if present. A response is considered an
+// error if it has a status code outside the 200 range.
+func CheckResponse(r *http.Response) error {
+	if c := r.StatusCode; c >= 200 && c <= 299 {
+		return nil
+	}
+	errorResponse := &ErrorResponse{Response: r}
+	return errorResponse
+}

--- a/pkg/here/routing.go
+++ b/pkg/here/routing.go
@@ -1,0 +1,59 @@
+package here
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// RoutingService handles communication with the routing related methods of the
+// HERE API.
+type RoutingService service
+
+type RoutingRequest struct {
+	// Mode of transport to be used for the calculation of the route.
+	TransportMode TransportMode
+	// A location defining origin of the trip.
+	Origin Waypoint
+	// A location defining destination of the trip.
+	Destination Waypoint
+	// A location defining a via waypoint.
+	// A via waypoint is a location between origin and destination.
+	// The route will do a stop at the via waypoint.
+	Via *Waypoint
+}
+
+// Get calculates a route using a generic vehicle/pedestrian mode, e.g. car, truck, pedestrian, etc...
+func (s *RoutingService) Get(ctx context.Context, req RoutingRequest) ([]byte, error) {
+	vals := url.Values{}
+	vals.Add("transportMode", req.TransportMode.String())
+	vals.Add("origin", req.Origin.String())
+	vals.Add("destination", req.Destination.String())
+	if req.Via != nil {
+		vals.Add("via", req.Via.String())
+	}
+	return s.getWithQueryAndPath(ctx, "routes", vals.Encode())
+}
+
+func (s *RoutingService) getWithQueryAndPath(
+	ctx context.Context,
+	path string,
+	query string,
+) ([]byte, error) {
+	u, err := s.URL.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := s.client.NewRequest(ctx, u, http.MethodGet, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create get request: %v", err)
+	}
+	var buf bytes.Buffer
+	err = s.client.Do(req, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get routes: %v", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/here/routingtypes.go
+++ b/pkg/here/routingtypes.go
@@ -1,0 +1,141 @@
+package here
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type TransportMode int
+
+const (
+	TransportModeCar TransportMode = iota
+	TransportModeTruck
+	TransportModePedestrian
+)
+
+func (t TransportMode) String() string {
+	var out string
+	switch t {
+	case TransportModeCar:
+		out = "car"
+	case TransportModeTruck:
+		out = "truck"
+	case TransportModePedestrian:
+		out = "pedestrian"
+	}
+	return out
+}
+
+type MatchSideOfStreet int
+
+const (
+	MatchSoSUnspecified MatchSideOfStreet = iota
+	MatchSoSOnlyIfDivided
+	MatchSoSAlways
+)
+
+func (h MatchSideOfStreet) String() string {
+	var out string
+	switch h {
+	case MatchSoSAlways:
+		out = "always"
+	case MatchSoSOnlyIfDivided:
+		out = "onlyIfDivided"
+	}
+	return out
+}
+
+type LatLong struct {
+	Lat  float64
+	Long float64
+}
+
+func (l LatLong) String() string {
+	return strconv.FormatFloat(l.Lat, 'f', 8, 64) + "," + strconv.FormatFloat(l.Long, 'f', 8, 64)
+}
+
+type PlaceOptions struct {
+	// Degrees clock-wise from north. Indicating desired direction at the place. E.g. 90 indicating east.
+	Course int
+	// SideOfStreetHint indicated the side of the street that should be used. E.g. if the location is to
+	// the left of the street, the router will prefer using that side in case the street has dividers.
+	// E.g. If Place is set to 52.511496,13.304140 and sideOfStreetHint=52.512149,13.304076 indicates that
+	// the north side of the street should be preferred.
+	// This option is required, if MatchSideOfStreet is set to always.
+	SideOfStreetHint LatLong
+	// MatchSideOfStreet specifies how the location set by sideOfStreetHint should be handled.
+	// Requires SideOfStreetHint to be specified as well.
+	//     always : 	   Always prefer the given side of street.
+	//     onlyIfDivided: Only prefer using side of street set by SideOfStreetHint in case the street has dividers.
+	//                    This is the default behavior.
+	MatchSideOfStreet MatchSideOfStreet
+	// NameHint causes the router to look for the place with the most similar name.
+	// This can e.g. include things like:
+	//     `North` being used to differentiate between interstates `I66 North` and `I66 South`.
+	//     `Downtown Avenue` being used to correctly select a residential street.
+	NameHint string
+	// Radius asks the router to consider all places within the given radius as potential candidates for route calculation.
+	// This can be either because it is not important which place is used, or because it is unknown.
+	// Radius more than 200meter are not supported.
+	// Specified in Meters.
+	Radius int
+	// Ask the routing service to try find a route that avoids actions for the indicated distance.
+	// E.g. if the origin is determined by a moving vehicle, the user might not have time to react to early actions.
+	// Specified in Meters.
+	MinCourseDistance int
+}
+
+func (o *PlaceOptions) String() string {
+	var out string
+
+	if o.Course != 0 {
+		out += fmt.Sprintf(";%d", o.Course)
+	}
+	if o.SideOfStreetHint.Lat != 0 || o.SideOfStreetHint.Long != 0 {
+		out += ";" + o.SideOfStreetHint.String()
+	}
+	if o.MatchSideOfStreet != MatchSoSUnspecified {
+		out += ";" + o.MatchSideOfStreet.String()
+	}
+	if o.NameHint != "" {
+		out += ";" + o.NameHint
+	}
+	if o.Radius != 0 {
+		out += fmt.Sprintf(";%d", o.Radius)
+	}
+	if o.MinCourseDistance != 0 {
+		out += fmt.Sprintf(";%d", o.MinCourseDistance)
+	}
+	return out
+}
+
+type WaypointOptions struct {
+	// Desired duration for the stop, in seconds.
+	// The section arriving at this via waypoint will have a wait post action reflecting the stopping time.
+	// The consecutive section will start at the arrival time of the former section + stop duration.
+	StopDuration int64
+}
+
+func (o *WaypointOptions) String() string {
+	var out string
+
+	if o.StopDuration != 0 {
+		out += fmt.Sprintf("!%d", o.StopDuration)
+	}
+	return out
+}
+
+type Waypoint struct {
+	Place           LatLong
+	PlaceOptions    PlaceOptions
+	WaypointOptions WaypointOptions
+}
+
+func (w *Waypoint) String() string {
+	var out string
+
+	out += w.Place.String()
+	out += w.PlaceOptions.String()
+	out += w.WaypointOptions.String()
+	return out
+}


### PR DESCRIPTION
Introduces a seed of a potential API Client for HERE

* Based on https://github.com/google/go-github and https://github.com/digitalocean/godo and also our own https://github.com/einride/balena-go
* Allows for generic authentication handled outside the library but includes an API Key implementation
* Minimal boiler plate for support JSON <--> struct requests (Though not used just yet as the Routing.Get response is not implemented
* Minimal, working, routing API support (See README). Only supports the mandatory fields and types
* No tests as if yet
