### PR TITLE
ci: add code coverage reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: yes
+
+ignore:
+  - internal/examples/proto/gen
+
+coverage:
+  range: "70...100"
+
+comment:
+  layout: reach,diff,flags,files
+  behavior: default
+  require_changes: no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Make
         run: make
 
+      - name: Report Code Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./build/coverage/go-test.txt
+          fail_ci_if_error: true
+
   release:
     needs: [make]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ include tools/golangci-lint/rules.mk
 include tools/goreview/rules.mk
 include tools/semantic-release/rules.mk
 
+.PHONY: clean
+clean:
+	$(info [$@] removing build files...)
+	@rm -rf build
+
 .PHONY: go-build
 go-build:
 	$(info [$@] cross-compiling to supported OSes...)
@@ -26,7 +31,8 @@ go-build:
 .PHONY: go-test
 go-test:
 	$(info [$@] running Go tests...)
-	@go test -count 1 -cover -race ./...
+	@mkdir -p build/coverage
+	@go test -short -race -coverprofile=build/coverage/$@.txt -covermode=atomic ./...
 
 .PHONY: go-mod-tidy
 go-mod-tidy:


### PR DESCRIPTION
Standard setup for our public repos.
