### PR TITLE
feat: add support for routing matrix v8 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,7 @@ API documentation can be found at [developer.here.com][api-docs].
 $ go get go.einride.tech/here
 ```
 
-## Examples
-
-### v7 Routing API
-
-Construct a new HERE client, then use the various services on the client
-to access different parts of the HERE API.
-
-#### Authentication
+## Authentication
 
 The package does not directly handle authentication. Instead, when
 creating a new client, pass an `http.Client` that can handle
@@ -41,6 +34,10 @@ authentication for you.
 Note that when using an authenticated Client, all calls made by the client
 will include the same authentication data. Therefore, authenticated
 clients should almost never be shared between different users.
+
+## Complete Examples
+
+### v7 Routing API
 
 #### Route calculation
 
@@ -59,6 +56,7 @@ import (
 func main() {
 	ctx := context.Background()
 	apiKey := os.Getenv("HERE_API_KEY")
+	// Create an authenticated client
 	routingClient := routingv7.New(
 		routingv7.NewAPIKeyHTTPClient(apiKey, http.DefaultClient.Transport),
 	)
@@ -72,6 +70,7 @@ func main() {
 		Lat:  59.337492,
 		Long: 18.063672,
 	}
+	// Call Here Maps API
 	response, err := routingClient.Route.CalculateRoute(ctx, &routingv7.CalculateRouteRequest{
 		Waypoints: []routingv7.WaypointParameter{origin, destination},
 		Mode: routingv7.RoutingMode{
@@ -81,8 +80,71 @@ func main() {
 	if err != nil {
 		panic(err) // TODO: Handle error.
 	}
+	// Handle result
 	for _, route := range response.Routes {
 		fmt.Println(route.Summary)
+	}
+}
+```
+
+### v8 Routing API
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"go.einride.tech/here/routingv8"
+)
+
+func main() {
+	ctx := context.Background()
+	apiKey := os.Getenv("HERE_API_KEY")
+	// Create an authenticated client
+	routingClient := routingv8.New(
+		routingv8.NewAPIKeyHTTPClient(apiKey, http.DefaultClient.Transport),
+	)
+	// Einride Gothenburg.
+	origins := []*routingv8.GeoWaypoint{
+		{
+			Lat:  57.707752,
+			Long: 11.949767,
+		},
+	}
+	// Einride Stockholm.
+	destinations := []*routingv8.GeoWaypoint{
+		{
+			Lat:  59.337492,
+			Long: 18.063672,
+		},
+	}
+	// Call Here Maps API
+	response, err := routingClient.Matrix.CalculateMatrix(ctx, &routingv8.CalculateMatrixRequest{
+		Async: false,
+		Body: &routingv8.CalculateMatrixBody{
+			Origins:      origins,
+			Destinations: destinations,
+			RegionDefinition: routingv8.RegionDefinition{
+				Type: routingv8.RegionType_World,
+			},
+			Profile: routingv8.Profile_TruckFast,
+			MatrixAttributes: &routingv8.MatrixAttributes{
+				routingv8.MatrixAttribute_Distances,
+				routingv8.MatrixAttribute_TravelTimes,
+			},
+		},
+	})
+	if err != nil {
+		panic(err) // TODO: handle error
+	}
+	// Handle result
+	fmt.Printf("matrix ID: %s \n", response.MatrixID)
+	for i, distance := range response.Matrix.Distances {
+		fmt.Printf("Route %d: %d meters \n", i, distance)
 	}
 }
 ```

--- a/routingv8/apikey.go
+++ b/routingv8/apikey.go
@@ -1,0 +1,29 @@
+package routingv8
+
+import "net/http"
+
+type apiKeyRoundTripper struct {
+	apiKey string
+	next   http.RoundTripper
+}
+
+// NewAPIKeyHTTPClient returns an HTTP Client which uses the given API Key.
+// If next is nil http.DefaultTransport is used.
+func NewAPIKeyHTTPClient(key string, next http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: &apiKeyRoundTripper{
+			apiKey: key,
+			next:   next,
+		},
+	}
+}
+
+func (r *apiKeyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	vals := req.URL.Query()
+	vals.Set("apiKey", r.apiKey)
+	req.URL.RawQuery = vals.Encode()
+	if r.next != nil {
+		return r.next.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/routingv8/calculatematrix.go
+++ b/routingv8/calculatematrix.go
@@ -1,0 +1,47 @@
+package routingv8
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+func (c *CalculateMatrixRequest) QueryString() string {
+	values := make(url.Values)
+	values.Add("async", c.Async.String())
+	return values.Encode()
+}
+
+// CalculateMatrix returns a matrix of route summaries.
+// The required parameters for this resource are a region definition and a set of start and destination waypoints.
+// See https://developer.here.com/documentation/matrix-routing-api/8.6.0/dev_guide/topics/get-started/send-request.html
+// for details about other parameters.
+func (s *MatrixService) CalculateMatrix(
+	ctx context.Context,
+	req *CalculateMatrixRequest,
+) (_ *CalculateMatrixResponse, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("calculate matrix: %v", err)
+		}
+	}()
+	u, err := s.URL.Parse("matrix")
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	r, err := s.Client.NewRequest(ctx, u, http.MethodPost, req.QueryString(), bytes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create post request: %v", err)
+	}
+	var resp CalculateMatrixResponse
+	if err := s.Client.Do(r, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/routingv8/client.go
+++ b/routingv8/client.go
@@ -1,0 +1,144 @@
+package routingv8
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	userAgent = "einride/here-go"
+)
+
+// MatrixService handles communication with the matrix-related methods of the v7 HERE API.
+type MatrixService service
+
+type Client struct {
+	// HTTP client used to communicate with the API.
+	client *http.Client
+
+	UserAgent string
+
+	// Matrix service.
+	Matrix *MatrixService
+}
+
+type service struct {
+	// URL for service API requests
+	URL    *url.URL
+	Client *Client
+}
+
+// An errorResponse reports the error caused by an API request.
+type errorResponse struct {
+	// HTTP response that caused this error
+	Response *HereErrorResponse
+}
+
+func (r *errorResponse) Error() string {
+	return fmt.Sprintf(
+		"Title: %v, Status: %d, Code: %v, Cause: %v, Action: %v",
+		r.Response.Title,
+		r.Response.Status,
+		r.Response.Code,
+		r.Response.Cause,
+		r.Response.Action,
+	)
+}
+
+// NewClient returns a new HERE API Client. If a nil httpClient is
+// provided, a new http.Client will be used. To use API methods which require
+// authentication, provide an http.Client that will perform the authentication
+// for you (such as that provided by the golang.org/x/oauth2 library).
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	c := &Client{client: httpClient, UserAgent: userAgent}
+	matrixURL, _ := url.Parse("https://matrix.router.hereapi.com/v8/")
+	c.Matrix = &MatrixService{URL: matrixURL, Client: c}
+	return c
+}
+
+// NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
+// BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
+// value pointed to by body is JSON encoded and included in as the request body.
+// A raw query string can be specified by rawQuery.
+func (c *Client) NewRequest(
+	ctx context.Context,
+	u *url.URL,
+	method string,
+	rawQuery string,
+	body []byte,
+) (*http.Request, error) {
+	if len(rawQuery) > 0 {
+		u.RawQuery = rawQuery
+	}
+	var r io.Reader
+	if len(body) > 0 {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), r)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	return req, nil
+}
+
+// Do sends an API request and returns the API response. The API response is JSON decoded and stored in the value
+// pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
+// the raw response will be written to v, without attempting to decode it.
+func (c *Client) Do(req *http.Request, v interface{}) error {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rerr := resp.Body.Close(); err == nil {
+			err = rerr
+		}
+	}()
+	err = checkResponse(resp)
+	if err != nil {
+		return err
+	}
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, err = io.Copy(w, resp.Body)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(v)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// checkResponse checks the API response for errors, and returns them if present. A response is considered an
+// error if it has a status code outside the 200 range.
+func checkResponse(r *http.Response) error {
+	if c := r.StatusCode; c >= 200 && c <= 299 {
+		return nil
+	}
+	var response HereErrorResponse
+	err := json.NewDecoder(r.Body).Decode(&response)
+	if err != nil {
+		return err
+	}
+	errorResponse := &errorResponse{Response: &response}
+	return errorResponse
+}

--- a/routingv8/examples/calculatematrix_example.go
+++ b/routingv8/examples/calculatematrix_example.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"go.einride.tech/here/routingv8"
+)
+
+func main() {
+	ctx := context.Background()
+	apiKey := os.Getenv("HERE_API_KEY")
+	routingClient := routingv8.NewClient(
+		routingv8.NewAPIKeyHTTPClient(apiKey, http.DefaultClient.Transport),
+	)
+	// Einride Gothenburg.
+	origins := []*routingv8.GeoWaypoint{
+		{
+			Lat:  57.707752,
+			Long: 11.949767,
+		},
+	}
+	// Einride Stockholm.
+	destinations := []*routingv8.GeoWaypoint{
+		{
+			Lat:  59.337492,
+			Long: 18.063672,
+		},
+	}
+
+	response, err := routingClient.Matrix.CalculateMatrix(ctx, &routingv8.CalculateMatrixRequest{
+		Async: false,
+		Body: &routingv8.CalculateMatrixBody{
+			Origins:      origins,
+			Destinations: destinations,
+			RegionDefinition: routingv8.RegionDefinition{
+				Type: routingv8.RegionTypeWorld,
+			},
+			Profile: routingv8.ProfileTruckFast,
+			MatrixAttributes: &routingv8.MatrixAttributes{
+				routingv8.MatrixAttributeDistances,
+				routingv8.MatrixAttributeTravelTimes,
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("matrix ID: %s \n", response.MatrixID)
+	for i, distance := range response.Matrix.Distances {
+		fmt.Printf("Route %d: %d meters \n", i, distance)
+	}
+}

--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -1,0 +1,421 @@
+package routingv8
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+const (
+	invalid     = "invalid"
+	unspecified = "unspecified"
+)
+
+type CalculateMatrixBody struct {
+	// Origins defining start points of the routes in the matrix.
+	// See https://developer.here.com/documentation/matrix-routing-api/8.6.0/dev_guide/topics/modes/modes.html
+	// for guidance on the matrix limitations.
+	Origins []*GeoWaypoint `json:"origins"`
+	// Destinations defining destinations of the routes in the matrix.
+	// See https://developer.here.com/documentation/matrix-routing-api/8.6.0/dev_guide/topics/modes/modes.html
+	// for guidance on the matrix limitations.
+	Destinations []*GeoWaypoint `json:"destinations"`
+	// DepartureTime of departure for all origins. Default to now.
+	DepartureTime string `json:"departureTime,omitempty"`
+	// RegionDefinition of where the matrix should be calculated.
+	RegionDefinition RegionDefinition `json:"regionDefinition"`
+	// Profile to use for route calculation in the matrix.
+	Profile Profile `json:"profile,omitempty"`
+	// RoutingMode optimization.
+	RoutingMode RoutingMode `json:"routingMode,omitempty"`
+	// TransportMode to use.
+	TransportMode TransportMode `json:"transportMode,omitempty"`
+	// MatrixAttributes to receive back in the response.
+	MatrixAttributes *MatrixAttributes `json:"matrixAttributes,omitempty"`
+	// Truck configuration
+	Truck *Truck `json:"truck,omitempty"`
+}
+
+type CalculateMatrixRequest struct {
+	// Async flag requires the Client to poll the calculation results and finally requesting to download
+	// the calculation results.
+	Async Async
+	// Body to pass to request to Here Maps API
+	Body *CalculateMatrixBody
+}
+
+type GeoWaypoint struct {
+	Lat  float64 `json:"lat,omitempty"`
+	Long float64 `json:"lng,omitempty"`
+}
+
+type Profile int
+
+const (
+	ProfileUnspecified = iota
+	// ProfileCarFast - Car with fast routing mode.
+	ProfileCarFast
+	// ProfileCarShort - Car with short routing mode.
+	ProfileCarShort
+	// ProfileTruckFast - Truck with fast routing mode.
+	ProfileTruckFast
+	// ProfilePedestrian - Pedestrian transport mode.
+	ProfilePedestrian
+	// ProfileBicycle - Bicycle transport mode.
+	ProfileBicycle
+)
+
+func (p *Profile) String() string {
+	switch *p {
+	case ProfileUnspecified:
+		return unspecified
+	case ProfileCarFast:
+		return "carFast"
+	case ProfileCarShort:
+		return "carShort"
+	case ProfileTruckFast:
+		return "truckFast"
+	case ProfilePedestrian:
+		// nolint:goconst
+		return "pedestrian"
+	case ProfileBicycle:
+		// nolint:goconst
+		return "bicycle"
+	default:
+		return invalid
+	}
+}
+
+func (p *Profile) UnmarshalString(value string) error {
+	switch value {
+	case "carFast":
+		*p = ProfileCarFast
+	case "carShort":
+		*p = ProfileCarShort
+	case "truckFast":
+		*p = ProfileTruckFast
+	case "pedestrian":
+		*p = ProfilePedestrian
+	case "bicycle":
+		*p = ProfileBicycle
+	default:
+		return fmt.Errorf("invalid profile")
+	}
+	return nil
+}
+
+func (p *Profile) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(p.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+func (p *Profile) UnmarshalJSON(b []byte) error {
+	value, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return p.UnmarshalString(value)
+}
+
+type RegionType int
+
+const (
+	RegionTypeUnspecified = iota
+	RegionTypeWorld
+	RegionTypeCircle
+	RegionTypeBoundingBox
+	RegionTypePolygon
+	RegionTypeAutoCircle
+)
+
+func (r *RegionType) String() string {
+	switch *r {
+	case RegionTypeUnspecified:
+		return unspecified
+	case RegionTypeWorld:
+		return "world"
+	case RegionTypeCircle:
+		return "circle"
+	case RegionTypeBoundingBox:
+		return "boundingBox"
+	case RegionTypePolygon:
+		return "polygon"
+	case RegionTypeAutoCircle:
+		return "autoCircle"
+	default:
+		return invalid
+	}
+}
+
+func (r *RegionType) UnmarshalString(value string) error {
+	switch value {
+	case "world":
+		*r = RegionTypeWorld
+	case "circle":
+		*r = RegionTypeCircle
+	case "boundingBox":
+		*r = RegionTypeBoundingBox
+	case "polygon":
+		*r = RegionTypePolygon
+	case "autoCircle":
+		*r = RegionTypeAutoCircle
+	default:
+		return fmt.Errorf("invalid region type")
+	}
+	return nil
+}
+
+func (r *RegionType) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(r.String())), nil
+}
+
+func (r *RegionType) UnmarshalJSON(b []byte) error {
+	value, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return r.UnmarshalString(value)
+}
+
+type RegionDefinition struct {
+	Type RegionType `json:"type"`
+	// Circle
+	CircleCenter *GeoWaypoint `json:"center,omitempty"`
+	CircleRadius int          `json:"radius,omitempty"`
+	// BoundingBox
+	BoundingBoxNorth int `json:"north,omitempty"`
+	BoundingBoxEast  int `json:"east,omitempty"`
+	BoundingBoxSouth int `json:"south,omitempty"`
+	BoundingBoxWest  int `json:"west,omitempty"`
+	// Polygon
+	PolygonOuter []*GeoWaypoint `json:"outer,omitempty"`
+	// AutoCircle
+	AutoCircleMargin int `json:"margin,omitempty"`
+}
+
+type Async bool
+
+func (a Async) String() string {
+	if a {
+		return "true"
+	}
+	return "false"
+}
+
+type MatrixAttribute int
+
+const (
+	MatrixAttributeUnspecified MatrixAttribute = iota
+	MatrixAttributeTravelTimes
+	MatrixAttributeDistances
+)
+
+func (m *MatrixAttribute) String() string {
+	switch *m {
+	case RegionTypeUnspecified:
+		return unspecified
+	case MatrixAttributeTravelTimes:
+		return "travelTimes"
+	case MatrixAttributeDistances:
+		return "distances"
+	default:
+		return invalid
+	}
+}
+
+type MatrixAttributes []MatrixAttribute
+
+func (m *MatrixAttributes) MarshalJSON() ([]byte, error) {
+	attributes := make([]string, 0, len(*m))
+	for _, attr := range *m {
+		attributes = append(attributes, attr.String())
+	}
+	b, err := json.Marshal(attributes)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+type RoutingMode int
+
+const (
+	RoutingModeUnspecified RoutingMode = iota
+	RoutingModeFast
+	RoutingModeShort
+)
+
+func (r *RoutingMode) String() string {
+	switch *r {
+	case RoutingModeUnspecified:
+		return unspecified
+	case RoutingModeFast:
+		return "fast"
+	case RoutingModeShort:
+		return "short"
+	default:
+		return invalid
+	}
+}
+
+func (r *RoutingMode) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(r.String())), nil
+}
+
+type TransportMode int
+
+const (
+	TransportModeUnspecified TransportMode = iota
+	TransportModeCar
+	TransportModeTruck
+	TransportModePedestrian
+	TransportModeBicycle
+	TransportModeTaxi
+	TransportModeScooter
+)
+
+func (t *TransportMode) String() string {
+	switch *t {
+	case RegionTypeUnspecified:
+		return unspecified
+	case TransportModeCar:
+		return "car"
+	case TransportModeTruck:
+		return "truck"
+	case TransportModePedestrian:
+		return "pedestrian"
+	case TransportModeBicycle:
+		return "bicycle"
+	case TransportModeTaxi:
+		return "taxi"
+	case TransportModeScooter:
+		return "scooter"
+	default:
+		return invalid
+	}
+}
+
+func (t *TransportMode) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(t.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+type ShippedHazardousGoods int
+
+const (
+	ShippedHazardousGoodsUnspecified ShippedHazardousGoods = iota
+	ShippedHazardousGoodsExplosive
+	ShippedHazardousGoodsGas
+	ShippedHazardousGoodsFlammable
+	ShippedHazardousGoodsCombustible
+	ShippedHazardousGoodsOrganic
+	ShippedHazardousGoodsPoison
+	ShippedHazardousGoodsRadioactive
+	ShippedHazardousGoodsCorrosive
+	ShippedHazardousGoodsPoisonousInhalation
+	ShippedHazardousGoodsHarmfulToWater
+	ShippedHazardousGoodsOther
+)
+
+func (s *ShippedHazardousGoods) String() string {
+	switch *s {
+	case ShippedHazardousGoodsUnspecified:
+		return unspecified
+	case ShippedHazardousGoodsExplosive:
+		return "explosive"
+	case ShippedHazardousGoodsGas:
+		return "gas"
+	case ShippedHazardousGoodsFlammable:
+		return "flammable"
+	case ShippedHazardousGoodsCombustible:
+		return "combustible"
+	case ShippedHazardousGoodsOrganic:
+		return "organic"
+	case ShippedHazardousGoodsPoison:
+		return "poison"
+	case ShippedHazardousGoodsRadioactive:
+		return "radioactive"
+	case ShippedHazardousGoodsCorrosive:
+		return "corrosive"
+	case ShippedHazardousGoodsPoisonousInhalation:
+		return "poisonousInhalation"
+	case ShippedHazardousGoodsHarmfulToWater:
+		return "harmfulToWater"
+	case ShippedHazardousGoodsOther:
+		return "other"
+	default:
+		return invalid
+	}
+}
+
+func (s *ShippedHazardousGoods) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(s.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+type ShippedHazardousGoodsList []ShippedHazardousGoods
+
+func (s *ShippedHazardousGoodsList) MarshalJSON() ([]byte, error) {
+	goods := make([]string, 0, len(*s))
+	for _, g := range *s {
+		goods = append(goods, g.String())
+	}
+	b, err := json.Marshal(goods)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+type TunnelCategory int
+
+const (
+	TunnelCategoryUnspecified TunnelCategory = iota
+	TunnelCategoryB
+	TunnelCategoryC
+	TunnelCategoryD
+	TunnelCategoryE
+)
+
+func (t *TunnelCategory) String() string {
+	switch *t {
+	case TunnelCategoryUnspecified:
+		return unspecified
+	case TunnelCategoryB:
+		return "B"
+	case TunnelCategoryC:
+		return "C"
+	case TunnelCategoryD:
+		return "D"
+	case TunnelCategoryE:
+		return "E"
+	default:
+		return invalid
+	}
+}
+
+func (t *TunnelCategory) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(t.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+type Truck struct {
+	ShippedHazardousGoods ShippedHazardousGoodsList `json:"shippedHazardousGoods"`
+	GrossWeight           int                       `json:"grossWeight"`
+	WeightPerAxle         int                       `json:"weightPerAxle"`
+	Height                int                       `json:"height"`
+	Width                 int                       `json:"width"`
+	Length                int                       `json:"length"`
+	TunnelCategory        TunnelCategory            `json:"tunnelCategory"`
+	AxleCount             int                       `json:"axleCount"`
+	TrailerCount          int                       `json:"trailerCount"`
+}

--- a/routingv8/response.go
+++ b/routingv8/response.go
@@ -1,0 +1,83 @@
+package routingv8
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type ErrorCode int
+
+// See https://developer.here.com/documentation/matrix-routing-api/8.6.0/api-reference-swagger.html
+// for detailed explanations of each error.
+const (
+	ErrorCodeUnspecified ErrorCode = iota
+	ErrorCodeSuccess
+	ErrorCodeDisconnected
+	ErrorCodeMatchingFailed
+	ErrorCodeParameterViolation
+	ErrorCodeUnknown
+)
+
+func (e *ErrorCode) UnmarshalString(value string) error {
+	switch value {
+	case "0":
+		*e = ErrorCodeSuccess
+	case "1":
+		*e = ErrorCodeDisconnected
+	case "2":
+		*e = ErrorCodeMatchingFailed
+	case "3":
+		*e = ErrorCodeParameterViolation
+	case "99":
+		*e = ErrorCodeUnknown
+	default:
+		return fmt.Errorf("invalid error code")
+	}
+	return nil
+}
+
+func (e *ErrorCode) UnmarshalJSON(b []byte) error {
+	value, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalString(value)
+}
+
+// MatrixResponse contains the calculated route matrix.
+type MatrixResponse struct {
+	// NumOrigins used to calculate matrix
+	NumOrigins int `json:"numOrigins"`
+	// NumDestinations used to calculate matrix
+	NumDestinations int `json:"numDestinations"`
+	// TravelTimes calculated using origins and destinations. Nil if not requested in MatrixAttributes.
+	TravelTimes []int32 `json:"travelTimes"`
+	// Distances calculated using origins and destinations. Nil if not requested in MatrixAttributes.
+	Distances []int32 `json:"distances"`
+	// ErrorCodes contains potential route errors. Nil if no errors occurred.
+	ErrorCodes []ErrorCode `json:"errorCodes"`
+}
+
+// CalculateMatrixResponse is used to provide results of a matrix calculation.
+type CalculateMatrixResponse struct {
+	// MatrixID is unique identifier of the matrix
+	MatrixID string `json:"matrixId"`
+	// Matrix contains the calculated matrix data.
+	Matrix MatrixResponse `json:"matrix"`
+	// RegionDefinition to be used to calculate matrix.
+	RegionDefinition RegionDefinition `json:"regionDefinition"`
+}
+
+// HereErrorResponse is returned when an error is returned from the Here Maps API.
+type HereErrorResponse struct {
+	// Title of the error
+	Title string `json:"title"`
+	// Http status code
+	Status int `json:"status"`
+	// Here Maps API error code
+	Code string `json:"code"`
+	// Cause of the error
+	Cause string `json:"cause"`
+	// Action Suggested to fix error
+	Action string `json:"action"`
+}


### PR DESCRIPTION
- Update readme
- CalculateMatrix method

A future improvement to add support for asynchronous help API endpoints: https://developer.here.com/documentation/matrix-routing-api/8.6.0/dev_guide/topics/get-started/asynchronous-request.html