### PR TITLE
fix: error codes unmarshalling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go.einride.tech/here
 
 go 1.14
+
+require gotest.tools/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/routingv8/calculatematrix_test.go
+++ b/routingv8/calculatematrix_test.go
@@ -1,0 +1,86 @@
+package routingv8_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"go.einride.tech/here/routingv8"
+	"gotest.tools/v3/assert"
+)
+
+type ClientMock struct {
+	responseStatus int
+	responseBody   routingv8.CalculateMatrixResponse
+}
+
+func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json")
+	b, err := json.Marshal(c.responseBody)
+	if err != nil {
+		return nil, err
+	}
+	r := bytes.NewReader(b)
+	return &http.Response{
+		StatusCode:    c.responseStatus,
+		Header:        headers,
+		Body:          io.NopCloser(r),
+		ContentLength: int64(len(b)),
+	}, nil
+}
+
+func TestMatrixService_CalculateMatrix(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	exp := routingv8.CalculateMatrixResponse{
+		MatrixID: "123",
+		Matrix: routingv8.MatrixResponse{
+			NumOrigins:      1,
+			NumDestinations: 1,
+			TravelTimes:     []int32{},
+			Distances:       []int32{1},
+			ErrorCodes:      routingv8.ErrorCodes{routingv8.ErrorCodeSuccess},
+		},
+		RegionDefinition: routingv8.RegionDefinition{
+			Type: routingv8.RegionTypeWorld,
+		},
+	}
+	httpClient := ClientMock{responseBody: exp, responseStatus: 200}
+	routingClient := routingv8.NewClient(&httpClient)
+	// Einride Gothenburg.
+	origins := []*routingv8.GeoWaypoint{
+		{
+			Lat:  57.707752,
+			Long: 11.949767,
+		},
+	}
+	// Einride Stockholm.
+	destinations := []*routingv8.GeoWaypoint{
+		{
+			Lat:  59.337492,
+			Long: 18.063672,
+		},
+	}
+	got, err := routingClient.Matrix.CalculateMatrix(ctx, &routingv8.CalculateMatrixRequest{
+		Async: false,
+		Body: &routingv8.CalculateMatrixBody{
+			Origins:      origins,
+			Destinations: destinations,
+			RegionDefinition: routingv8.RegionDefinition{
+				Type: routingv8.RegionTypeWorld,
+			},
+			Profile: routingv8.ProfileTruckFast,
+			MatrixAttributes: &routingv8.MatrixAttributes{
+				routingv8.MatrixAttributeDistances,
+				routingv8.MatrixAttributeTravelTimes,
+			},
+		},
+	})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, &exp, got)
+}

--- a/routingv8/client.go
+++ b/routingv8/client.go
@@ -14,12 +14,16 @@ const (
 	userAgent = "einride/here-go"
 )
 
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // MatrixService handles communication with the matrix-related methods of the v7 HERE API.
 type MatrixService service
 
 type Client struct {
 	// HTTP client used to communicate with the API.
-	client *http.Client
+	client HTTPClient
 
 	UserAgent string
 
@@ -54,7 +58,7 @@ func (r *errorResponse) Error() string {
 // provided, a new http.Client will be used. To use API methods which require
 // authentication, provide an http.Client that will perform the authentication
 // for you (such as that provided by the golang.org/x/oauth2 library).
-func NewClient(httpClient *http.Client) *Client {
+func NewClient(httpClient HTTPClient) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}

--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -168,7 +168,7 @@ func (r *RegionType) UnmarshalString(value string) error {
 	return nil
 }
 
-func (r *RegionType) MarshalJSON() ([]byte, error) {
+func (r RegionType) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.Quote(r.String())), nil
 }
 


### PR DESCRIPTION
There was an issue where unmarshalling responses that contained an `errorCodes` property failed due to incorrect handling of the enum slice in the `UnmarshalJSON` for `ErrorCode`