### PR TITLE
fix(routingv8): do not omit empty lat long json fields

### DIFF
--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -47,8 +47,8 @@ type CalculateMatrixRequest struct {
 }
 
 type GeoWaypoint struct {
-	Lat  float64 `json:"lat,omitempty"`
-	Long float64 `json:"lng,omitempty"`
+	Lat  float64 `json:"lat"`
+	Long float64 `json:"lng"`
 }
 
 // DepartureTimeAny enforces non time-aware routing.


### PR DESCRIPTION
Sending a coordinate with either latitude or longitude set to 0 should not omit the corresponding field when converting to json.