### PR TITLE
feat: avoid features as optional parameter to routes

### DIFF
--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -50,6 +50,7 @@ type RoutesRequest struct {
 	Origin        GeoWaypoint
 	Destination   GeoWaypoint
 	TransportMode TransportMode
+	AvoidAreas    []AreaFeature
 }
 
 type GeoWaypoint struct {
@@ -428,4 +429,38 @@ type Truck struct {
 	TunnelCategory        TunnelCategory            `json:"tunnelCategory"`
 	AxleCount             int                       `json:"axleCount"`
 	TrailerCount          int                       `json:"trailerCount"`
+}
+
+type AreaFeature int
+
+const (
+	AreaFeatureUnspecified AreaFeature = iota
+	AreaFeatureFerry
+	AreaFeatureTollRoad
+	AreaFeatureTunnel
+	AreaFeatureControlledAccessHighway
+)
+
+func (t *AreaFeature) String() string {
+	switch *t {
+	case AreaFeatureUnspecified:
+		return unspecified
+	case AreaFeatureFerry:
+		return "ferry"
+	case AreaFeatureTollRoad:
+		return "tollRoad"
+	case AreaFeatureTunnel:
+		return "tunnel"
+	case AreaFeatureControlledAccessHighway:
+		return "controlledAccessHighway"
+	default:
+		return invalid
+	}
+}
+
+func (t *AreaFeature) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(t.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
 }

--- a/routingv8/routes.go
+++ b/routingv8/routes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // Routes returns all possible routes between origin and destination.
@@ -29,6 +30,21 @@ func (s *RoutingService) Routes(
 	values.Add("transportMode", tm)
 	values.Add("origin", fmt.Sprintf("%v,%v", req.Origin.Lat, req.Origin.Long))
 	values.Add("destination", fmt.Sprintf("%v,%v", req.Destination.Lat, req.Destination.Long))
+
+	if req.AvoidAreas != nil {
+		var avoidString string
+		for _, a := range req.AvoidAreas {
+			avoid := a.String()
+			if avoid == invalid {
+				return nil, fmt.Errorf("invalid avoid area")
+			}
+			if avoid != unspecified {
+				avoidString += fmt.Sprintf("%s,%s", avoidString, avoid)
+			}
+		}
+		avoidString = strings.Trim(avoidString, ",")
+		values.Add("avoid[features]", avoidString)
+	}
 
 	r, err := s.Client.NewRequest(ctx, u, http.MethodGet, values.Encode(), nil)
 	if err != nil {


### PR DESCRIPTION
Routes takes an optional parameter Avoid Areas that is a list of features to avoid such as Ferry, Tunnel etc. The here-api will attempt to avoid the specified feature but if no other route is available it may still return a route that demands that feature.