### PR TITLE
feat: Add Geocoding that allows forward/reverse geocode addresses and geo-positions

### DIFF
--- a/geocodingsearchv7/apikey.go
+++ b/geocodingsearchv7/apikey.go
@@ -1,0 +1,29 @@
+package geocodingsearchv7
+
+import "net/http"
+
+type apiKeyRoundTripper struct {
+	apiKey string
+	next   http.RoundTripper
+}
+
+// NewAPIKeyHTTPClient returns an HTTP Client which uses the given API Key.
+// If next is nil http.DefaultTransport is used.
+func NewAPIKeyHTTPClient(key string, next http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: &apiKeyRoundTripper{
+			apiKey: key,
+			next:   next,
+		},
+	}
+}
+
+func (r *apiKeyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	vals := req.URL.Query()
+	vals.Set("apiKey", r.apiKey)
+	req.URL.RawQuery = vals.Encode()
+	if r.next != nil {
+		return r.next.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/geocodingsearchv7/client.go
+++ b/geocodingsearchv7/client.go
@@ -1,0 +1,154 @@
+package geocodingsearchv7
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	userAgent = "einride/here-go"
+)
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// GeocodingService handles communication with geocoding-related methods of the v7 HERE API.
+type GeocodingService service
+
+// ReverseGeocodingService handles communication with reverse geocoding-related methods of the v7 HERE API.
+type ReverseGeocodingService service
+
+type Client struct {
+	// HTTP client used to communicate with the API.
+	client HTTPClient
+
+	UserAgent string
+
+	// Geocoding service
+	Geocoding *GeocodingService
+	// ReverseGeocoding service
+	ReverseGeocoding *ReverseGeocodingService
+}
+
+type service struct {
+	// URL for service API requests
+	URL    *url.URL
+	Client *Client
+}
+
+// A responseError reports the error caused by an API request.
+type responseError struct {
+	// HTTP response that caused this error
+	Response *HereErrorResponse
+}
+
+func (r *responseError) Error() string {
+	return fmt.Sprintf(
+		"Title: %v, Status: %d, Code: %v, Cause: %v, Action: %v",
+		r.Response.Title,
+		r.Response.Status,
+		r.Response.Code,
+		r.Response.Cause,
+		r.Response.Action,
+	)
+}
+
+// NewClient returns a new HERE API Client. If a nil httpClient is
+// provided, a new http.Client will be used. To use API methods which require
+// authentication, provide an http.Client that will perform the authentication
+// for you (such as that provided by the golang.org/x/oauth2 library).
+func NewClient(httpClient HTTPClient) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	c := &Client{client: httpClient, UserAgent: userAgent}
+	geocodingURL, _ := url.Parse("https://geocode.search.hereapi.com/v1/")
+	c.Geocoding = &GeocodingService{URL: geocodingURL, Client: c}
+	reverseGeocodingURL, _ := url.Parse("https://revgeocode.search.hereapi.com/v1/")
+	c.ReverseGeocoding = &ReverseGeocodingService{URL: reverseGeocodingURL, Client: c}
+	return c
+}
+
+// NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
+// BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
+// value pointed to by body is JSON encoded and included in as the request body.
+// A raw query string can be specified by rawQuery.
+func (c *Client) NewRequest(
+	ctx context.Context,
+	u *url.URL,
+	method string,
+	rawQuery string,
+	body []byte,
+) (*http.Request, error) {
+	if len(rawQuery) > 0 {
+		u.RawQuery = rawQuery
+	}
+	var r io.Reader
+	if len(body) > 0 {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), r)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	return req, nil
+}
+
+// Do sends an API request and returns the API response. The API response is JSON decoded and stored in the value
+// pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
+// the raw response will be written to v, without attempting to decode it.
+func (c *Client) Do(req *http.Request, v interface{}) error {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rerr := resp.Body.Close(); err == nil {
+			err = rerr
+		}
+	}()
+	err = checkResponse(resp)
+	if err != nil {
+		return err
+	}
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, err = io.Copy(w, resp.Body)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(v)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// checkResponse checks the API response for errors, and returns them if present. A response is considered an
+// error if it has a status code outside the 200 range.
+func checkResponse(r *http.Response) error {
+	if c := r.StatusCode; c >= 200 && c <= 299 {
+		return nil
+	}
+	var response HereErrorResponse
+	err := json.NewDecoder(r.Body).Decode(&response)
+	if err != nil {
+		return err
+	}
+	return &responseError{Response: &response}
+}

--- a/geocodingsearchv7/geocoding.go
+++ b/geocodingsearchv7/geocoding.go
@@ -1,0 +1,89 @@
+package geocodingsearchv7
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Geocoding allows forward geocoding of addresses and geo-positions.
+// See https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics/quick-start.html#send-a-request
+// for details about other parameters.
+func (s *GeocodingService) Geocoding(
+	ctx context.Context,
+	req *GeocodingRequest,
+) (_ *GeocodingResponse, err error) {
+	u, err := s.URL.Parse("geocode")
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Q == nil && req.Address == nil {
+		return nil, fmt.Errorf("InvalidArgument, either Q or QQ must be provided")
+	}
+
+	values := make(url.Values)
+	if req.GeoPosition != nil {
+		values.Add("at", fmt.Sprintf("%v,%v", req.GeoPosition.Lat, req.GeoPosition.Long))
+	}
+	if req.Q != nil {
+		values.Add("q", *req.Q)
+	}
+	if req.Address != nil {
+		values.Add("qq", FormatQualifiedQuery(*req.Address))
+	}
+	if req.In != nil {
+		values.Add("in", *req.In)
+	}
+
+	r, err := s.Client.NewRequest(ctx, u, http.MethodGet, values.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create get request: %v", err)
+	}
+	var resp GeocodingResponse
+	if err := s.Client.Do(r, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// FormatQualifiedQuery takes an address and formats it into a qualified query.
+// The resulting string will look like <key1>=<value1>;<key2>=<value2>;...
+// where the keys are all fields of the address object and the values are their values.
+func FormatQualifiedQuery(address AddressRequest) string {
+	var qq string
+	if address.Country != "" {
+		qq = addSubParam(qq, "country", address.Country)
+	}
+	if address.State != "" {
+		qq = addSubParam(qq, "state", address.State)
+	}
+	if address.County != "" {
+		qq = addSubParam(qq, "county", address.County)
+	}
+	if address.City != "" {
+		qq = addSubParam(qq, "city", address.City)
+	}
+	if address.District != "" {
+		qq = addSubParam(qq, "district", address.District)
+	}
+	if address.Street != "" {
+		qq = addSubParam(qq, "street", address.Street)
+	}
+	if address.HouseNumber != "" {
+		qq = addSubParam(qq, "houseNumber", address.HouseNumber)
+	}
+	if address.PostalCode != "" {
+		qq = addSubParam(qq, "postalCode", address.PostalCode)
+	}
+	return qq
+}
+
+func addSubParam(query string, paramName string, value string) string {
+	if query != "" {
+		query = fmt.Sprintf("%s;", query)
+	}
+	query = fmt.Sprintf("%s%s=%s", query, paramName, value)
+	return query
+}

--- a/geocodingsearchv7/geocoding_test.go
+++ b/geocodingsearchv7/geocoding_test.go
@@ -1,0 +1,108 @@
+package geocodingsearchv7_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"go.einride.tech/here/geocodingsearchv7"
+	"gotest.tools/v3/assert"
+)
+
+type GeocodingMock struct {
+	responseStatus int
+	responseBody   geocodingsearchv7.GeocodingResponse
+}
+
+func (c *GeocodingMock) Do(req *http.Request) (*http.Response, error) {
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json")
+	b, err := json.Marshal(c.responseBody)
+	if err != nil {
+		return nil, err
+	}
+	r := bytes.NewReader(b)
+	return &http.Response{
+		StatusCode:    c.responseStatus,
+		Header:        headers,
+		Body:          io.NopCloser(r),
+		ContentLength: int64(len(b)),
+	}, nil
+}
+
+func TestGeocodingService_Geocoding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run(
+		"when neither address or query is given as input, then return invalid argument",
+		func(t *testing.T) {
+			t.Parallel()
+			httpClient := GeocodingMock{responseBody: geocodingsearchv7.GeocodingResponse{}, responseStatus: 200}
+			routingClient := geocodingsearchv7.NewClient(&httpClient)
+
+			_, err := routingClient.Geocoding.Geocoding(ctx, &geocodingsearchv7.GeocodingRequest{
+				Address: nil, // Address is nil
+				Q:       nil, // Query is nil
+			})
+			assert.ErrorContains(t, err, "InvalidArgument")
+		},
+	)
+}
+
+func TestGeocodingService_FormatQualifiedQuery(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"when using one parameter",
+		func(t *testing.T) {
+			t.Parallel()
+			req := geocodingsearchv7.AddressRequest{
+				Country: "Sweden",
+			}
+			res := geocodingsearchv7.FormatQualifiedQuery(req)
+			assert.Equal(t, res, "country=Sweden")
+		},
+	)
+
+	t.Run(
+		"when using two parameters",
+		func(t *testing.T) {
+			t.Parallel()
+			req := geocodingsearchv7.AddressRequest{
+				Country: "Sweden",
+				City:    "Stockholm",
+			}
+			res := geocodingsearchv7.FormatQualifiedQuery(req)
+			assert.Equal(t, res, "country=Sweden;city=Stockholm")
+		},
+	)
+
+	t.Run(
+		"when using multiple parameters",
+		func(t *testing.T) {
+			t.Parallel()
+			req := geocodingsearchv7.AddressRequest{
+				Country:     "Sweden",
+				City:        "Stockholm",
+				Street:      "Regeringsgatan",
+				HouseNumber: "65",
+			}
+			res := geocodingsearchv7.FormatQualifiedQuery(req)
+			assert.Equal(t, res, "country=Sweden;city=Stockholm;street=Regeringsgatan;houseNumber=65")
+		},
+	)
+
+	t.Run(
+		"when using no parameters, then return empty qq",
+		func(t *testing.T) {
+			t.Parallel()
+			req := geocodingsearchv7.AddressRequest{}
+			res := geocodingsearchv7.FormatQualifiedQuery(req)
+			assert.Equal(t, res, "")
+		},
+	)
+}

--- a/geocodingsearchv7/request.go
+++ b/geocodingsearchv7/request.go
@@ -1,0 +1,48 @@
+package geocodingsearchv7
+
+type GeoWaypoint struct {
+	Lat  float64 `json:"lat"`
+	Long float64 `json:"lng"`
+}
+
+type GeocodingRequest struct {
+	// Specify the center of the search context expressed as coordinates.
+	GeoPosition *GeoWaypoint
+	// Free text search query. Example: "Regeringsgatan 65, Stockholm"
+	// Either Q, or Address-parameter is required.
+	Q *string
+	// The address to search for. Works similar to free text query but separates parameters.
+	Address *AddressRequest
+	// Search within a geographic area.
+	// Results will be returned if they are located within the specified area.
+	// a country (or multiple countries), provided as comma-separated ISO 3166-1 alpha-3 country codes.
+	In *string
+}
+
+type AddressRequest struct {
+	// The country name.
+	Country string `json:"country,omitempty"`
+	// The state name.
+	State string `json:"state,omitempty"`
+	// The county name.
+	County string `json:"county,omitempty"`
+	// The city name.
+	City string `json:"city,omitempty"`
+	// The district.
+	District string `json:"district,omitempty"`
+	// The street name.
+	Street string `json:"street,omitempty"`
+	// The house number.
+	HouseNumber string `json:"houseNumber,omitempty"`
+	// The postal code.
+	PostalCode string `json:"postalCode,omitempty"`
+}
+
+type ReverseGeocodingRequest struct {
+	// Specify the coordinates to perform a reverse geocoding. Returns the closest address given the coordinates.
+	GeoPosition *GeoWaypoint
+	// Search within a geographic area.
+	// Results will be returned if they are located within the specified area.
+	// a country (or multiple countries), provided as comma-separated ISO 3166-1 alpha-3 country codes.
+	In *string
+}

--- a/geocodingsearchv7/response.go
+++ b/geocodingsearchv7/response.go
@@ -1,0 +1,116 @@
+package geocodingsearchv7
+
+type GeocodingResponse struct {
+	Items []GeocodingItem
+}
+
+type GeocodingItem struct {
+	// A representative string for the result, for instance the name of a place, or a complete address.
+	Title string `json:"title,omitempty"`
+	// The identifier of the item. Its value can be used to retrieve the very same object using the /lookup endpoint.
+	ID string `json:"id,omitempty"`
+	// HERE Geocoding and Search supports multiple location object types (place, street, locality, ...).
+	ResultType string `json:"resultType,omitempty"`
+	// Type of address data (returned only for address results). Is one of PA or interpolated.
+	// PA - Point Address, location matches as individual point object.
+	// interpolated - location was interpolated from an address range.
+	HouseNumberType string `json:"houseNumberType,omitempty"`
+	// The result address in its related fields.
+	Address Address `json:"address,omitempty"`
+	// A representative geo-position (WGS 84) of the result; this is to be used to display the result on a map.
+	Position GeoWaypoint `json:"position,omitempty"`
+	// The geo-position of the access to the result (for instance the entrance).
+	Access []GeoWaypoint `json:"access,omitempty"`
+	// Bounding box of the location optimized for display.
+	MapView MapView `json:"mapView,omitempty"`
+	// indicates for each result how good it matches to the original query.
+	// This can be used by the customer application to accept or reject
+	// the results depending on how “expensive” is the mistake for their use case.
+	Scoring Scoring `json:"scoring,omitempty"`
+}
+
+type ReverseGeocodingResponse struct {
+	Items []ReverseGeocodingItem
+}
+
+type ReverseGeocodingItem struct {
+	// A representative string for the result, for instance the name of a place, or a complete address.
+	Title string `json:"title,omitempty"`
+	// The identifier of the item. Its value can be used to retrieve the very same object using the /lookup endpoint.
+	ID string `json:"id,omitempty"`
+	// HERE Geocoding and Search supports multiple location object types (place, street, locality, ...).
+	ResultType string `json:"resultType,omitempty"`
+	// Type of address data (returned only for address results). Is one of PA or interpolated.
+	// PA - Point Address, location matches as individual point object.
+	// interpolated - location was interpolated from an address range.
+	HouseNumberType string `json:"houseNumberType,omitempty"`
+	// The result address in its related fields.
+	Address Address `json:"address,omitempty"`
+	// A representative geo-position (WGS 84) of the result; this is to be used to display the result on a map.
+	Position GeoWaypoint `json:"position,omitempty"`
+	// The geo-position of the access to the result (for instance the entrance).
+	Access []GeoWaypoint `json:"access,omitempty"`
+	// Bounding box of the location optimized for display.
+	MapView MapView `json:"mapView,omitempty"`
+	// The distance in meters to the given spatial context ('at=lat,lon').
+	Distance int `json:"distance,omitempty"`
+}
+
+type Address struct {
+	// A representative string for the result, for instance the name of a place, or a complete address.
+	Label string `json:"label,omitempty"`
+	// The country code.
+	CountryCode string `json:"countryCode,omitempty"`
+	// The country name.
+	CountryName string `json:"countryName,omitempty"`
+	// The state code.
+	StateCode string `json:"stateCode,omitempty"`
+	// The state name.
+	State string `json:"state,omitempty"`
+	// The county code.
+	CountyCode string `json:"countyCode,omitempty"`
+	// The county name.
+	CountyName string `json:"countyName,omitempty"`
+	// The city name.
+	City string `json:"city,omitempty"`
+	// The district.
+	District string `json:"district,omitempty"`
+	// The street name.
+	Street string `json:"street,omitempty"`
+	// The postal code.
+	PostalCode string `json:"postalCode,omitempty"`
+	// The house number.
+	HouseNumber string `json:"houseNumber,omitempty"`
+}
+
+type MapView struct {
+	West  float64 `json:"west,omitempty"`
+	South float64 `json:"south,omitempty"`
+	East  float64 `json:"east,omitempty"`
+	North float64 `json:"north,omitempty"`
+}
+
+type Scoring struct {
+	QueryScore float64    `json:"queryScore,omitempty"`
+	FieldScore FieldScore `json:"fieldScore,omitempty"`
+}
+
+type FieldScore struct {
+	City        float64   `json:"city,omitempty"`
+	Streets     []float64 `json:"streets,omitempty"`
+	HouseNumber float64   `json:"houseNumber,omitempty"`
+}
+
+// HereErrorResponse is returned when an error is returned from the Here Maps API.
+type HereErrorResponse struct {
+	// Title of the error
+	Title string `json:"title"`
+	// Http status code
+	Status int `json:"status"`
+	// Here Maps API error code
+	Code string `json:"code"`
+	// Cause of the error
+	Cause string `json:"cause"`
+	// Action Suggested to fix error
+	Action string `json:"action"`
+}

--- a/geocodingsearchv7/reversegeocoding.go
+++ b/geocodingsearchv7/reversegeocoding.go
@@ -1,0 +1,43 @@
+package geocodingsearchv7
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ReverseGeocoding allows reverse geocode from geo-position to address.
+// See https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html
+// for more details.
+func (s *ReverseGeocodingService) ReverseGeocoding(
+	ctx context.Context,
+	req *ReverseGeocodingRequest,
+) (*ReverseGeocodingResponse, error) {
+	u, err := s.URL.Parse("revgeocode")
+	if err != nil {
+		return nil, err
+	}
+
+	if req.GeoPosition == nil {
+		return nil, fmt.Errorf("InvalidArgument, GeoPosition must be provided")
+	}
+
+	values := make(url.Values)
+	if req.GeoPosition != nil {
+		values.Add("at", fmt.Sprintf("%v,%v", req.GeoPosition.Lat, req.GeoPosition.Long))
+	}
+	if req.In != nil {
+		values.Add("in", *req.In)
+	}
+
+	r, err := s.Client.NewRequest(ctx, u, http.MethodGet, values.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create get request: %v", err)
+	}
+	var resp ReverseGeocodingResponse
+	if err := s.Client.Do(r, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/geocodingsearchv7/reversegeocoding_test.go
+++ b/geocodingsearchv7/reversegeocoding_test.go
@@ -1,0 +1,51 @@
+package geocodingsearchv7_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"go.einride.tech/here/geocodingsearchv7"
+	"gotest.tools/v3/assert"
+)
+
+type ReverseGeocodingMock struct {
+	responseStatus int
+	responseBody   geocodingsearchv7.ReverseGeocodingResponse
+}
+
+func (c *ReverseGeocodingMock) Do(req *http.Request) (*http.Response, error) {
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json")
+	b, err := json.Marshal(c.responseBody)
+	if err != nil {
+		return nil, err
+	}
+	r := bytes.NewReader(b)
+	return &http.Response{
+		StatusCode:    c.responseStatus,
+		Header:        headers,
+		Body:          io.NopCloser(r),
+		ContentLength: int64(len(b)),
+	}, nil
+}
+
+func TestReverseGeocodingService_ReverseGeocoding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run(
+		"when geoposition is missing from request, then return invalid argument",
+		func(t *testing.T) {
+			t.Parallel()
+			httpClient := ReverseGeocodingMock{responseBody: geocodingsearchv7.ReverseGeocodingResponse{}, responseStatus: 200}
+			routingClient := geocodingsearchv7.NewClient(&httpClient)
+
+			_, err := routingClient.ReverseGeocoding.ReverseGeocoding(ctx, &geocodingsearchv7.ReverseGeocodingRequest{})
+			assert.ErrorContains(t, err, "InvalidArgument")
+		},
+	)
+}

--- a/routingv8/response.go
+++ b/routingv8/response.go
@@ -65,7 +65,7 @@ type RoutesResponse struct {
 
 // Route contains all the sections of a route.
 type Route struct {
-	// Id of the route
+	// ID of the route
 	ID string `json:"id"`
 	// Sections in the route
 	Sections []Section `json:"sections"`
@@ -73,7 +73,7 @@ type Route struct {
 
 // Section with the information of the departure, arrival location and summary.
 type Section struct {
-	// Id of the section
+	// ID of the section
 	ID string `json:"id"`
 	// The type used in the section
 	Type string `json:"type"`


### PR DESCRIPTION
Implements connection to Here Api:s [Geocoding and Search Api](https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics/quick-start.html#send-a-request).

Add function `Geocoding` that can do forward and reverse geocoding based on free text search query, a qualified query or lat/lng coordinates.