### PR TITLE
feat: Add batch geocoding to allow forward/reverse geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,41 @@ func main() {
 	}
 }
 ```
+
+### v7 Geocoding & Search API
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"go.einride.tech/here/geocodingsearchv7"
+)
+
+func main() {
+	ctx := context.Background()
+	apiKey := os.Getenv("HERE_API_KEY")
+	// Create an authenticated client
+	geocodingClient := geocodingsearchv7.NewClient(
+		geocodingsearchv7.NewAPIKeyHTTPClient(apiKey, http.DefaultClient.Transport),
+	)
+
+	// The query to geocode
+	q := "Regeringsgatan 65, Stocholm"
+	// Call Here Maps API
+	response, err := geocodingClient.Geocoding.Geocoding(ctx, &geocodingsearchv7.GeocodingRequest{
+		Q: &q,
+	})
+	if err != nil {
+		panic(err) // TODO: handle error
+	}
+	// Handle result
+	for _, item := range response.Items {
+		fmt.Printf("Geocoded location lat/lng: %f %f  \n", item.Position.Lat, item.Position.Long)
+	}
+}
+```

--- a/geocodingsearchv7/batchgeocoder.go
+++ b/geocodingsearchv7/batchgeocoder.go
@@ -1,0 +1,192 @@
+package geocodingsearchv7
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// BatchGeocoderUpload allows batch forward geocoding of addresses.
+// See https://developer.here.com/documentation/batch-geocoder/dev_guide/topics/introduction.html
+// for details about other parameters.
+func (s *BatchGeocodingService) BatchGeocoderUpload(
+	ctx context.Context,
+	req *BatchGeocoderUploadRequest,
+) (_ *BatchGeocoderResponse, err error) {
+	if req.Addresses != nil && req.Queries != nil {
+		return nil, fmt.Errorf(
+			"InvalidArgument, only one of Addresses or Queries can be used in the same request",
+		)
+	}
+	if req.Addresses == nil && req.Queries == nil {
+		return nil, fmt.Errorf("InvalidArgument, one of Addresses or Queries must be supplied")
+	}
+	u, err := s.URL.Parse("jobs")
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(url.Values)
+	values.Add("action", "run")
+	values.Add("indelim", "|")
+	values.Add("outdelim", "|")
+	values.Add("outcols", "displayLatitude,displayLongitude,locationLabel,houseNumber,street,"+
+		"district,city,postalCode,county,state,country")
+	values.Add("outputCombined", "false")
+
+	var body []byte
+	if req.Addresses != nil {
+		body = geoAddressesBody(req.Addresses)
+	} else if req.Queries != nil {
+		body = queryBody(req.Queries)
+	}
+
+	r, err := s.Client.NewRequest(ctx, u, http.MethodPost, values.Encode(), body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create post request: %v", err)
+	}
+	var resp BatchGeocoderResponse
+	if err := s.Client.DoXML(r, &resp); err != nil {
+		return nil, fmt.Errorf("DoXML failed: %v", err)
+	}
+	return &resp, nil
+}
+
+// BatchReverseGeocoderUpload allows batch reverse geocoding of geo-positions.
+// See https://developer.here.com/documentation/batch-geocoder/dev_guide/topics/introduction.html
+// for details about other parameters.
+func (s *BatchGeocodingService) BatchReverseGeocoderUpload(
+	ctx context.Context,
+	req *BatchReverseGeocoderUploadRequest,
+) (_ *BatchGeocoderResponse, err error) {
+	if req.GeoPositions == nil {
+		return nil, fmt.Errorf("InvalidArgument, geoPositions must be in the request")
+	}
+	u, err := s.URL.Parse("jobs")
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(url.Values)
+	values.Add("action", "run")
+	values.Add("indelim", "|")
+	values.Add("outdelim", "|")
+	values.Add("outcols", "displayLatitude,displayLongitude,locationLabel,houseNumber,street,"+
+		"district,city,postalCode,county,state,country")
+	values.Add("outputCombined", "false")
+	// Used to signal to Here that reverse geocoding should be performed
+	values.Add("mode", "retrieveAddresses")
+
+	body := geoPositionBody(req.GeoPositions)
+
+	r, err := s.Client.NewRequest(ctx, u, http.MethodPost, values.Encode(), body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create post request: %v", err)
+	}
+	var resp BatchGeocoderResponse
+	if err := s.Client.DoXML(r, &resp); err != nil {
+		return nil, fmt.Errorf("DoXML failed: %v", err)
+	}
+	return &resp, nil
+}
+
+// BatchGeocoderStatus check status of batch geocoder job. The requestId was obtained in the BatchGeocoderUpload call
+// that started the job.
+// https://developer.here.com/documentation/examples/rest/batch_geocoding/batch-geocode-job-status
+// for details about other parameters.
+func (s *BatchGeocodingService) BatchGeocoderStatus(
+	ctx context.Context,
+	req *BatchGeocoderStatusRequest,
+) (_ *BatchGeocoderResponse, err error) {
+	if req.RequestID == "" {
+		return nil, fmt.Errorf("InvalidArgument, requestID can not be empty")
+	}
+	u, err := s.URL.Parse(fmt.Sprintf("jobs/%s", req.RequestID))
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(url.Values)
+	values.Add("action", "status")
+
+	r, err := s.Client.NewRequest(ctx, u, http.MethodGet, values.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create get request: %v", err)
+	}
+	var resp BatchGeocoderResponse
+	if err := s.Client.DoXML(r, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BatchGeocoderDownload downloads the results of the completed batch geocoding job and returns the results as
+// a zipped csv file.
+// The requestId was obtained in the BatchGeocoderUpload call that started the job.
+// Return an io.Writer with the zipped csv file.
+// https://developer.here.com/documentation/examples/rest/batch_geocoding/download-geocoded-data
+// for details about other parameters.
+func (s *BatchGeocodingService) BatchGeocoderDownload(
+	ctx context.Context,
+	req *BatchGeocoderDownloadRequest,
+	w io.Writer,
+) error {
+	if req.RequestID == "" {
+		return fmt.Errorf("InvalidArgument, requestID can not be empty")
+	}
+	u, err := s.URL.Parse(fmt.Sprintf("jobs/%s/result", req.RequestID))
+	if err != nil {
+		return err
+	}
+	r, err := s.Client.NewRequest(ctx, u, http.MethodGet, "", nil)
+	if err != nil {
+		return fmt.Errorf("unable to create get request: %v", err)
+	}
+	if err := s.Client.DoXML(r, w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func geoPositionBody(p []*GeoWaypointRequest) []byte {
+	var b []byte
+	cols := "recId|prox"
+	b = []byte(cols)
+	for _, e := range p {
+		b = append(b, []byte(fmt.Sprintf("\n%v|%v,%v", e.RecID, e.GeoPositions.Lat, e.GeoPositions.Long))...)
+	}
+	return b
+}
+
+func geoAddressesBody(addresses []*AddressRequest) []byte {
+	var b []byte
+	cols := "recId|street|houseNumber|district|city|postalCode|county|state|country"
+	b = []byte(cols)
+	for _, a := range addresses {
+		address := fmt.Sprintf(
+			"%s|%s|%s|%s|%s|%s|%s|%s",
+			a.Street,
+			a.HouseNumber,
+			a.District,
+			a.City,
+			a.PostalCode,
+			a.County,
+			a.State,
+			a.Country,
+		)
+		b = append(b, []byte(fmt.Sprintf("\n%v|%s", a.RecID, address))...)
+	}
+	return b
+}
+
+func queryBody(queries []*QueryString) []byte {
+	var b []byte
+	cols := "recId|searchText|country"
+	b = []byte(cols)
+	for _, a := range queries {
+		b = append(b, []byte(fmt.Sprintf("\n%v|%s|%s", a.RecID, a.Query, a.Country))...)
+	}
+	return b
+}

--- a/geocodingsearchv7/batchgeocoder_test.go
+++ b/geocodingsearchv7/batchgeocoder_test.go
@@ -1,0 +1,109 @@
+package geocodingsearchv7_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"go.einride.tech/here/geocodingsearchv7"
+	"gotest.tools/v3/assert"
+)
+
+type BatchGeocodingMock struct {
+	responseStatus int
+	responseBody   geocodingsearchv7.BatchGeocoderResponse
+}
+
+func (c *BatchGeocodingMock) Do(req *http.Request) (*http.Response, error) {
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json")
+	b, err := json.Marshal(c.responseBody)
+	if err != nil {
+		return nil, err
+	}
+	r := bytes.NewReader(b)
+	return &http.Response{
+		StatusCode:    c.responseStatus,
+		Header:        headers,
+		Body:          io.NopCloser(r),
+		ContentLength: int64(len(b)),
+	}, nil
+}
+
+func TestBatchGeocodingService_BatchGeocode(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"when both addresses and queries are nil, then return InvalidArgument",
+		func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			httpClient := BatchGeocodingMock{responseBody: geocodingsearchv7.BatchGeocoderResponse{}, responseStatus: 200}
+			routingClient := geocodingsearchv7.NewClient(&httpClient)
+
+			_, err := routingClient.BatchGeocoding.BatchGeocoderUpload(ctx, &geocodingsearchv7.BatchGeocoderUploadRequest{
+				Addresses: nil,
+				Queries:   nil,
+			})
+			assert.ErrorContains(t, err, "InvalidArgument")
+		},
+	)
+	t.Run(
+		"when both addresses and queries are not set, then return InvalidArgument ",
+		func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			httpClient := BatchGeocodingMock{responseBody: geocodingsearchv7.BatchGeocoderResponse{}, responseStatus: 200}
+			routingClient := geocodingsearchv7.NewClient(&httpClient)
+
+			_, err := routingClient.BatchGeocoding.BatchGeocoderUpload(ctx, &geocodingsearchv7.BatchGeocoderUploadRequest{
+				Addresses: []*geocodingsearchv7.AddressRequest{},
+				Queries:   []*geocodingsearchv7.QueryString{},
+			})
+			assert.ErrorContains(t, err, "InvalidArgument")
+		},
+	)
+}
+
+func TestBatchGeocodingService_BatchGeocodeStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"when requestID is empty, then return InvalidArgument",
+		func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			httpClient := BatchGeocodingMock{responseBody: geocodingsearchv7.BatchGeocoderResponse{}, responseStatus: 200}
+			routingClient := geocodingsearchv7.NewClient(&httpClient)
+
+			_, err := routingClient.BatchGeocoding.BatchGeocoderStatus(ctx, &geocodingsearchv7.BatchGeocoderStatusRequest{
+				RequestID: "",
+			})
+			assert.ErrorContains(t, err, "InvalidArgument")
+		},
+	)
+}
+
+func TestBatchGeocodingService_BatchGeocodeDownload(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"when requestID is empty, then return InvalidArgument",
+		func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			httpClient := BatchGeocodingMock{responseBody: geocodingsearchv7.BatchGeocoderResponse{}, responseStatus: 200}
+			routingClient := geocodingsearchv7.NewClient(&httpClient)
+
+			err := routingClient.BatchGeocoding.BatchGeocoderDownload(
+				ctx,
+				&geocodingsearchv7.BatchGeocoderDownloadRequest{RequestID: ""},
+				nil,
+			)
+			assert.ErrorContains(t, err, "InvalidArgument")
+		},
+	)
+}

--- a/geocodingsearchv7/geocoding.go
+++ b/geocodingsearchv7/geocoding.go
@@ -20,7 +20,7 @@ func (s *GeocodingService) Geocoding(
 	}
 
 	if req.Q == nil && req.Address == nil {
-		return nil, fmt.Errorf("InvalidArgument, either Q or QQ must be provided")
+		return nil, fmt.Errorf("InvalidArgument, either Queries or QQ must be provided")
 	}
 
 	values := make(url.Values)

--- a/geocodingsearchv7/request.go
+++ b/geocodingsearchv7/request.go
@@ -20,7 +20,9 @@ type GeocodingRequest struct {
 }
 
 type AddressRequest struct {
-	// The country name.
+	// The id to recognize this address with, will be returned in result from HERE as recId
+	RecID string `json:"recId,omitempty"`
+	// The country name or country code in ISO 3166-1-alpha-3 format.
 	Country string `json:"country,omitempty"`
 	// The state name.
 	State string `json:"state,omitempty"`
@@ -38,6 +40,13 @@ type AddressRequest struct {
 	PostalCode string `json:"postalCode,omitempty"`
 }
 
+type GeoWaypointRequest struct {
+	// The id to recognize this address with, will be returned in result from HERE as recId
+	RecID string `json:"recId,omitempty"`
+	// Coordinates to perform reverse geocoding on to retrieve the address.
+	GeoPositions *GeoWaypoint
+}
+
 type ReverseGeocodingRequest struct {
 	// Specify the coordinates to perform a reverse geocoding. Returns the closest address given the coordinates.
 	GeoPosition *GeoWaypoint
@@ -45,4 +54,35 @@ type ReverseGeocodingRequest struct {
 	// Results will be returned if they are located within the specified area.
 	// a country (or multiple countries), provided as comma-separated ISO 3166-1 alpha-3 country codes.
 	In *string
+}
+
+type BatchGeocoderUploadRequest struct {
+	// List of free text search query, one query per address.
+	Queries []*QueryString
+	// The addresses to search for. Works similar to free text query but separates parameters.
+	Addresses []*AddressRequest
+}
+
+type BatchReverseGeocoderUploadRequest struct {
+	// Coordinates to perform reverse geocoding on to retrieve the address, and id.
+	GeoPositions []*GeoWaypointRequest
+}
+
+type BatchGeocoderStatusRequest struct {
+	// RequestID for the job to fetch the status on, was obtained from the call to BatchGeocoderUpload.
+	RequestID string
+}
+
+type BatchGeocoderDownloadRequest struct {
+	// RequestID for the job to fetch the result on, was obtained from the call to BatchGeocoderUpload.
+	RequestID string
+}
+
+type QueryString struct {
+	// The id to recognize this address with, will be returned in result from HERE as recId
+	RecID string `json:"recId,omitempty"`
+	// The free text query.
+	Query string
+	// The country of where the free query refers to, in ISO 3166-1 alpha-3 format.
+	Country string
 }

--- a/geocodingsearchv7/response.go
+++ b/geocodingsearchv7/response.go
@@ -104,13 +104,60 @@ type FieldScore struct {
 // HereErrorResponse is returned when an error is returned from the Here Maps API.
 type HereErrorResponse struct {
 	// Title of the error
-	Title string `json:"title"`
+	Title string `json:"title" xml:"title"`
 	// Http status code
-	Status int `json:"status"`
+	Status int `json:"status" xml:"status"`
 	// Here Maps API error code
-	Code string `json:"code"`
+	Code string `json:"code" xml:"code"`
 	// Cause of the error
-	Cause string `json:"cause"`
+	Cause string `json:"cause" xml:"cause"`
 	// Action Suggested to fix error
-	Action string `json:"action"`
+	Action string `json:"action" xml:"action"`
+}
+
+type BatchGeocoderResponse struct {
+	Response struct {
+		MetaInfo struct {
+			RequestID string `xml:"RequestId,omitempty"`
+		}
+		Status         JobStatus `xml:"Status,omitempty"`
+		TotalCount     int       `xml:"TotalCount,omitempty"`
+		ValidCount     int       `xml:"ValidCount,omitempty"`
+		InvalidCount   int       `xml:"InvalidCount,omitempty"`
+		ProcessedCount int       `xml:"ProcessedCount,omitempty"`
+		PendingCount   int       `xml:"PendingCount,omitempty"`
+		SuccessCount   int       `xml:"SuccessCount,omitempty"`
+		ErrorCount     int       `xml:"ErrorCount,omitempty"`
+		JobStarted     string    `xml:"JobStarted,omitempty"`
+		JobFinished    string    `xml:"JobFinished,omitempty"`
+	}
+}
+
+type JobStatus string
+
+const (
+	JobStatusAccepted  = "accepted"
+	JobStatusCancelled = "canceled"
+	JobStatusCompleted = "completed"
+	JobStatusDeleted   = "deleted"
+	JobStatusFailed    = "failed"
+	JobStatusRunning   = "running"
+	JobStatusSubmitted = "submitted"
+)
+
+type BatchGeocoderResponseRow struct {
+	RecID            string  `csv:"recId"`
+	SeqNumber        int     `csv:"SeqNumber"`
+	SeqLength        int     `csv:"seqLength"`
+	DisplayLatitude  float64 `csv:"displayLatitude"`
+	DisplayLongitude float64 `csv:"displayLongitude"`
+	LocationLabel    string  `csv:"locationLabel"`
+	HouseNumber      string  `csv:"houseNumber"`
+	Street           string  `csv:"street"`
+	District         string  `csv:"district"`
+	City             string  `csv:"city"`
+	PostalCode       string  `csv:"postalCode"`
+	County           string  `csv:"county"`
+	State            string  `csv:"state"`
+	Country          string  `csv:"country"`
 }


### PR DESCRIPTION
Implementation towards [HERE Batch Geocoder API ](https://developer.here.com/documentation/batch-geocoder/dev_guide/topics/introduction.html) that allows forward and reverse geocoding.

`BatchGeocoderUpload` - Used to upload addresses to be forward geocoded.
`BatchReverseGeocoderUpload` - Used to upload geocoordinates to be reverse geocoded.
`BatchGeocoderStatus` - Returns the current status of the job.
`BatchGeocoderDownload` - Used to download zipped file with results of job.