### PR TITLE
feat(TRA-1006): specify string type of DepartureTimeAny constant

### DIFF
--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -80,7 +80,7 @@ type GeoWaypoint struct {
 }
 
 // DepartureTimeAny enforces non time-aware routing.
-const DepartureTimeAny = "any"
+const DepartureTimeAny string = "any"
 
 type Profile int
 


### PR DESCRIPTION
An untyped string constant makes it a bit more of a hassle to parameterize `DepartureTime` in hexagonal (data ports) services that use this library. 

For example, consider this data port interface `CalculateDrivingRoute(ctx context.Context, origin, destination model.LatLng, departureTime *string) (*DrivingRoute, error)` which exist in Orchestrate service where I want to allow passing either nil, an RFC 3339 timestamp string or `routingv8.DepartureTimeAny`.

If I want to specify `routingv8.DepartureTimeAny`, I will have to do something like this to work around the untyped string constant type:
```
departureTimeAny = routingv8.DepartureTimeAny
drivingRoute, err := p.CalculateDrivingRoute(ctx, input.Origin, input.Destination, &departureTimeAny)
```

This change will now allow us to do the following:
```
drivingRoute, err := p.CalculateDrivingRoute(ctx, input.Origin, input.Destination, &routingv8.DepartureTimeAny)
```

As far as I know (and tested), changing from an untyped string to a typed string is not a breaking change!