### PR TITLE
feat: Add support for Route Import

### DIFF
--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -493,6 +493,7 @@ type SpanAttribute string
 const (
 	SpanAttributeNames    SpanAttribute = "names"
 	SpanAttributeMaxSpeed SpanAttribute = "maxSpeed"
+	SpanAttributeLength   SpanAttribute = "length"
 )
 
 func (t *SpanAttribute) String() string {
@@ -501,6 +502,8 @@ func (t *SpanAttribute) String() string {
 		return string(SpanAttributeNames)
 	case SpanAttributeMaxSpeed:
 		return string(SpanAttributeMaxSpeed)
+	case SpanAttributeLength:
+		return string(SpanAttributeLength)
 	default:
 		return invalid
 	}

--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -505,3 +505,22 @@ func (t *SpanAttribute) String() string {
 		return invalid
 	}
 }
+
+type RouteImportRequest struct {
+	TransportMode TransportMode
+	// Which attributes to return in the response.
+	// If not specified defaults to SummaryReturnAttribute.
+	Return []ReturnAttribute
+	// The time of departure.
+	// If not specified the current time is used.
+	// To not take time into account use DepartureTimeAny.
+	DepartureTime string
+	// Spans define which content attributes that are included in the response spans
+	Spans []SpanAttribute
+	// An array of GPS coordinates
+	Trace []GeoWaypoint
+}
+
+type RouteImportRequestBody struct {
+	Trace []GeoWaypoint `json:"trace"`
+}

--- a/routingv8/routes_test.go
+++ b/routingv8/routes_test.go
@@ -15,6 +15,7 @@ import (
 
 type RoutesMock struct {
 	requestRawQuery string
+	requestRawBody  string
 	responseStatus  int
 	responseBody    routingv8.RoutesResponse
 	error           *routingv8.HereErrorResponse
@@ -22,6 +23,15 @@ type RoutesMock struct {
 
 func (c *RoutesMock) Do(req *http.Request) (*http.Response, error) {
 	c.requestRawQuery = req.URL.RawQuery
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			panic(err)
+		}
+		c.requestRawBody = string(body)
+	} else {
+		c.requestRawBody = ""
+	}
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json")
 	b, err := json.Marshal(c.responseBody)
@@ -242,6 +252,221 @@ func TestRoutingervice_Routes_Error(t *testing.T) {
 		Origin:        origin,
 		Destination:   destination,
 		TransportMode: routingv8.TransportModeCar,
+	})
+	var responseError *routingv8.ResponseError
+	assert.Check(t, errors.As(err, &responseError))
+	assert.DeepEqual(t, responseError.Response, &exp)
+	assert.Check(t, responseError.HTTPBody != "")
+}
+
+func TestRoutingervice_RouteImport(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Einride Gothenburg.
+	origin := routingv8.GeoWaypoint{
+		Elevation: 1,
+		Lat:       57.707752,
+		Long:      11.949767,
+	}
+	// Einride Stockholm.
+	destination := routingv8.GeoWaypoint{
+		Elevation: 2,
+		Lat:       59.337492,
+		Long:      18.063672,
+	}
+
+	exp := routingv8.RoutesResponse{
+		Routes: []routingv8.Route{
+			{
+				ID: "route-1",
+				Sections: []routingv8.Section{
+					{
+						ID:   "section-1",
+						Type: "veicle",
+						Departure: routingv8.VehicleDeparture{
+							Place: routingv8.Place{
+								Type:             "place",
+								Location:         origin,
+								OriginalLocation: origin,
+							},
+						},
+						Arrival: routingv8.VehicleDeparture{
+							Place: routingv8.Place{
+								Type:             "place",
+								Location:         destination,
+								OriginalLocation: destination,
+							},
+						},
+						Summary: routingv8.Summary{
+							Duration:     243,
+							Length:       1206,
+							BaseDuration: 136,
+						},
+					},
+				},
+			},
+		},
+	}
+	httpClient := RoutesMock{responseBody: exp, responseStatus: 200}
+	routingClient := routingv8.NewClient(&httpClient)
+
+	got, err := routingClient.Routing.RouteImport(ctx, &routingv8.RouteImportRequest{
+		Trace: []routingv8.GeoWaypoint{
+			origin,
+			destination,
+		},
+		TransportMode: routingv8.TransportModeCar,
+	})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, &exp, got)
+}
+
+func TestRoutingervice_RouteImport_QueryParams(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Einride Gothenburg.
+	origin := routingv8.GeoWaypoint{
+		Lat:  57.707752,
+		Long: 11.949767,
+	}
+	// Einride Stockholm.
+	destination := routingv8.GeoWaypoint{
+		Lat:  59.337492,
+		Long: 18.063672,
+	}
+	traceBody := `{"trace":[{"lat":57.707752,"lng":11.949767},{"lat":59.337492,"lng":18.063672}]}`
+
+	for _, tt := range []struct {
+		name              string
+		request           *routingv8.RouteImportRequest
+		expectedURLParams string
+		expectedBody      string
+		errStr            string
+	}{
+		{
+			name: "minimal",
+			request: &routingv8.RouteImportRequest{
+				Trace: []routingv8.GeoWaypoint{
+					origin,
+					destination,
+				},
+				TransportMode: routingv8.TransportModeCar,
+			},
+			expectedURLParams: "return=summary&transportMode=car",
+			expectedBody:      traceBody,
+		},
+		{
+			name: "multiple return attributes",
+			request: &routingv8.RouteImportRequest{
+				Trace: []routingv8.GeoWaypoint{
+					origin,
+					destination,
+				},
+				TransportMode: routingv8.TransportModeCar,
+				Return: []routingv8.ReturnAttribute{
+					routingv8.SummaryReturnAttribute,
+					routingv8.PolylineReturnAttribute,
+				},
+			},
+			expectedURLParams: "return=summary%2Cpolyline&transportMode=car",
+			expectedBody:      traceBody,
+		},
+		{
+			name: "with spans",
+			request: &routingv8.RouteImportRequest{
+				Trace: []routingv8.GeoWaypoint{
+					origin,
+					destination,
+				},
+				TransportMode: routingv8.TransportModeCar,
+				Return: []routingv8.ReturnAttribute{
+					routingv8.SummaryReturnAttribute,
+					routingv8.PolylineReturnAttribute,
+				},
+				Spans: []routingv8.SpanAttribute{
+					routingv8.SpanAttributeNames,
+					routingv8.SpanAttributeMaxSpeed,
+				},
+			},
+			expectedURLParams: "return=summary%2Cpolyline&spans=names%2CmaxSpeed&transportMode=car",
+			expectedBody:      traceBody,
+		},
+		{
+			name: "trace with too few point",
+			request: &routingv8.RouteImportRequest{
+				Trace: []routingv8.GeoWaypoint{
+					origin,
+				},
+				TransportMode: routingv8.TransportModeCar,
+			},
+			errStr: "trace parameter must contain at least 2 waypoints",
+		},
+		{
+			name: "with spans without wanted polyline returned",
+			request: &routingv8.RouteImportRequest{
+				Trace: []routingv8.GeoWaypoint{
+					origin,
+					destination,
+				},
+				TransportMode: routingv8.TransportModeCar,
+				Return: []routingv8.ReturnAttribute{
+					routingv8.SummaryReturnAttribute,
+				},
+				Spans: []routingv8.SpanAttribute{
+					routingv8.SpanAttributeNames,
+					routingv8.SpanAttributeMaxSpeed,
+				},
+			},
+			errStr: "spans parameter also requires that the polyline option is set in the return parameter",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := RoutesMock{}
+			routingClient := routingv8.NewClient(&client)
+
+			_, err := routingClient.Routing.RouteImport(ctx, tt.request)
+			if tt.errStr != "" {
+				assert.ErrorContains(t, err, tt.errStr)
+			}
+			assert.Equal(t, client.requestRawQuery, tt.expectedURLParams)
+			assert.Equal(t, client.requestRawBody, tt.expectedBody)
+		})
+	}
+}
+
+func TestRoutingervice_RouteImport_Error(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Einride Gothenburg.
+	origin := routingv8.GeoWaypoint{
+		Lat:  57.707752,
+		Long: 11.949767,
+	}
+	// Einride Stockholm.
+	destination := routingv8.GeoWaypoint{
+		Lat:  59.337492,
+		Long: 18.063672,
+	}
+
+	exp := routingv8.HereErrorResponse{
+		Title:  "Mocked Error",
+		Status: 400,
+	}
+
+	httpClient := RoutesMock{responseStatus: 400, error: &exp}
+	routingClient := routingv8.NewClient(&httpClient)
+
+	_, err := routingClient.Routing.RouteImport(ctx, &routingv8.RouteImportRequest{
+		Trace: []routingv8.GeoWaypoint{
+			origin,
+			destination,
+		},
+		TransportMode: routingv8.TransportModeTruck,
 	})
 	var responseError *routingv8.ResponseError
 	assert.Check(t, errors.As(err, &responseError))


### PR DESCRIPTION
- feat: Add support for Route Import 
  This implementation of RouteImport() only supports the same subset of parameters as Routes()
- feat: Add support for "length" span attribute