### PR TITLE
ci(dependabot): update interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
   - package-ecosystem: gomod
     directory: .sage
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
## Update dependabot interval
### Why?
- We are getting a lot of these dependabot PRs, and often!
### What?
- Update schedule to monthly interval.
### Notes
- This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
