### PR TITLE
feat(routingv8): add place-snap hints to GeoWaypoint

### DIFF
--- a/routingv8/calculatematrix_test.go
+++ b/routingv8/calculatematrix_test.go
@@ -84,3 +84,131 @@ func TestMatrixService_CalculateMatrix(t *testing.T) {
 	assert.NilError(t, err)
 	assert.DeepEqual(t, &exp, got)
 }
+
+func TestCalculateMatrixBody_MarshalJSON(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		body routingv8.CalculateMatrixBody
+		want string
+	}{
+		{
+			name: "bare coordinates omit snap hints",
+			body: routingv8.CalculateMatrixBody{
+				Origins:      []*routingv8.GeoWaypoint{{Lat: 57.707752, Long: 11.949767}},
+				Destinations: []*routingv8.GeoWaypoint{{Lat: 59.337492, Long: 18.063672}},
+				RegionDefinition: routingv8.RegionDefinition{
+					Type: routingv8.RegionTypeWorld,
+				},
+				TransportMode: routingv8.TransportModeTruck,
+			},
+			want: `{` +
+				`"origins":[{"lat":57.707752,"lng":11.949767}],` +
+				`"destinations":[{"lat":59.337492,"lng":18.063672}],` +
+				`"regionDefinition":{"type":"world"},` +
+				`"transportMode":"truck"` +
+				`}`,
+		},
+		{
+			name: "snap hints emit radius and radiusPenalty",
+			body: routingv8.CalculateMatrixBody{
+				Origins: []*routingv8.GeoWaypoint{
+					{Lat: 57.707752, Long: 11.949767, Radius: 200, RadiusPenalty: 5000},
+				},
+				Destinations: []*routingv8.GeoWaypoint{
+					{Lat: 59.337492, Long: 18.063672, Radius: 200, RadiusPenalty: 5000},
+				},
+				RegionDefinition: routingv8.RegionDefinition{
+					Type: routingv8.RegionTypeWorld,
+				},
+				TransportMode: routingv8.TransportModeTruck,
+			},
+			want: `{` +
+				`"origins":[{"lat":57.707752,"lng":11.949767,"radius":200,"radiusPenalty":5000}],` +
+				`"destinations":[{"lat":59.337492,"lng":18.063672,"radius":200,"radiusPenalty":5000}],` +
+				`"regionDefinition":{"type":"world"},` +
+				`"transportMode":"truck"` +
+				`}`,
+		},
+		{
+			name: "snapRadius emits snapRadius",
+			body: routingv8.CalculateMatrixBody{
+				Origins: []*routingv8.GeoWaypoint{
+					{Lat: 57.707752, Long: 11.949767, SnapRadius: 50},
+				},
+				Destinations: []*routingv8.GeoWaypoint{
+					{Lat: 59.337492, Long: 18.063672, SnapRadius: 50},
+				},
+				RegionDefinition: routingv8.RegionDefinition{
+					Type: routingv8.RegionTypeWorld,
+				},
+				TransportMode: routingv8.TransportModeTruck,
+			},
+			want: `{` +
+				`"origins":[{"lat":57.707752,"lng":11.949767,"snapRadius":50}],` +
+				`"destinations":[{"lat":59.337492,"lng":18.063672,"snapRadius":50}],` +
+				`"regionDefinition":{"type":"world"},` +
+				`"transportMode":"truck"` +
+				`}`,
+		},
+		{
+			name: "course hints emit course and minCourseDistance",
+			body: routingv8.CalculateMatrixBody{
+				Origins: []*routingv8.GeoWaypoint{
+					{Lat: 57.707752, Long: 11.949767, Course: 90, MinCourseDistance: 500},
+				},
+				Destinations: []*routingv8.GeoWaypoint{
+					{Lat: 59.337492, Long: 18.063672},
+				},
+				RegionDefinition: routingv8.RegionDefinition{
+					Type: routingv8.RegionTypeWorld,
+				},
+				TransportMode: routingv8.TransportModeTruck,
+			},
+			want: `{` +
+				`"origins":[{"lat":57.707752,"lng":11.949767,"course":90,"minCourseDistance":500}],` +
+				`"destinations":[{"lat":59.337492,"lng":18.063672}],` +
+				`"regionDefinition":{"type":"world"},` +
+				`"transportMode":"truck"` +
+				`}`,
+		},
+		{
+			name: "sideOfStreetHint embeds match",
+			body: routingv8.CalculateMatrixBody{
+				Origins: []*routingv8.GeoWaypoint{
+					{
+						Lat:  52.511496,
+						Long: 13.304140,
+						SideOfStreetHint: &routingv8.SideOfStreetHint{
+							Lat:   52.512149,
+							Long:  13.304076,
+							Match: routingv8.SideOfStreetMatchAlways,
+						},
+					},
+				},
+				Destinations: []*routingv8.GeoWaypoint{
+					{Lat: 59.337492, Long: 18.063672},
+				},
+				RegionDefinition: routingv8.RegionDefinition{
+					Type: routingv8.RegionTypeWorld,
+				},
+				TransportMode: routingv8.TransportModeTruck,
+			},
+			want: `{` +
+				`"origins":[{"lat":52.511496,"lng":13.30414,` +
+				`"sideOfStreetHint":{"lat":52.512149,"lng":13.304076,"match":"always"}}],` +
+				`"destinations":[{"lat":59.337492,"lng":18.063672}],` +
+				`"regionDefinition":{"type":"world"},` +
+				`"transportMode":"truck"` +
+				`}`,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(&tt.body)
+			assert.NilError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}

--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -79,7 +79,66 @@ type GeoWaypoint struct {
 	Elevation float64 `json:"elv,omitempty"`
 	Lat       float64 `json:"lat"`
 	Long      float64 `json:"lng"`
+	// Radius instructs the router to consider all places within the given
+	// radius as potential candidates for matching the waypoint. Specified
+	// in meters. Range: [0-200]. Values higher than 200 meters are not
+	// supported. Cannot be combined with SnapRadius.
+	Radius int `json:"radius,omitempty"`
+	// RadiusPenalty is a percentage applied to candidates within Radius
+	// based on their air distance to the waypoint, where 100 is just the
+	// cost of the air distance and 200 is twice the cost. The penalty
+	// must be chosen so that, when multiplied by the radius, the result
+	// is less than or equal to 7200; values up to and including 10000 are
+	// accepted regardless. Range: [0-10000]. Cannot be combined with
+	// SnapRadius.
+	//
+	// Alpha: This parameter is in development. It may not be stable and
+	// is subject to change.
+	RadiusPenalty int `json:"radiusPenalty,omitempty"`
+	// SnapRadius instructs the router to match the waypoint, within the
+	// specified radius, to the most "significant" road, sorting candidates
+	// by significance (e.g. highway > national road > city road).
+	// Specified in meters. Range: [0-1000000]. Cannot be combined with
+	// Radius or RadiusPenalty.
+	SnapRadius int `json:"snapRadius,omitempty"`
+	// Course is the direction in degrees clockwise from north (0 is
+	// north) from which this waypoint should be approached or in which it
+	// should be left. Range: [0-359]. Values outside the range are
+	// wrapped to the range.
+	Course float64 `json:"course,omitempty"`
+	// MinCourseDistance instructs the routing service to try to find a
+	// route that avoids actions for the indicated distance. For example,
+	// if the origin is determined by a moving vehicle, the user might not
+	// have time to react to early actions. Specified in meters. Values
+	// greater than 2000 meters will be capped at 2000 meters.
+	MinCourseDistance int `json:"minCourseDistance,omitempty"`
+	// SideOfStreetHint is a point next to the street (e.g. a POI) that
+	// indicates which side of the street should be preferred for this
+	// waypoint when the street has dividers.
+	SideOfStreetHint *SideOfStreetHint `json:"sideOfStreetHint,omitempty"`
 }
+
+// SideOfStreetHint is a hint as to which side of the street should be
+// preferred for a waypoint. The hint should be a point next to the
+// street, e.g. a POI.
+type SideOfStreetHint struct {
+	Lat  float64 `json:"lat"`
+	Long float64 `json:"lng"`
+	// Match determines how the side-of-street hint should be handled.
+	// Defaults to SideOfStreetMatchOnlyIfDivided when unset.
+	Match SideOfStreetMatch `json:"match,omitempty"`
+}
+
+// SideOfStreetMatch determines how a SideOfStreetHint should be handled.
+type SideOfStreetMatch string
+
+const (
+	// SideOfStreetMatchAlways always uses the side-of-street hint.
+	SideOfStreetMatchAlways SideOfStreetMatch = "always"
+	// SideOfStreetMatchOnlyIfDivided only uses the side-of-street hint
+	// on divided roads. This is HERE's default behavior.
+	SideOfStreetMatchOnlyIfDivided SideOfStreetMatch = "onlyIfDivided"
+)
 
 // DepartureTimeAny enforces non time-aware routing.
 const DepartureTimeAny = "any"


### PR DESCRIPTION
The HERE Matrix Routing v8 postmatrix Waypoint schema accepts a family
of optional hints that bias how the router relocates an input
coordinate to the road network: the radius/snapRadius pair with a
penalty modifier, an approach-direction hint with a "don't action this
early" distance, and an explicit side-of-street hint. Surface them on
`GeoWaypoint` so callers can express the full HERE feature set without
reaching past the SDK.

Add, with `omitempty` so existing callers continue to emit bare
`{lat,lng}` bodies:

  - `Radius` (`int` meters, max 200) and `RadiusPenalty` (`int32`
    percent, 0-10000). Per the schema, `RadiusPenalty` also has a
    `penalty * radius <= 7200` constraint enforced by the server;
    document it rather than validate, matching how `Truck.GrossWeight`
    and `Vehicle.*` are handled in this file (units and ranges in
    comments only). Mark `RadiusPenalty` Alpha — the schema flags it as
    such and we mirror that with a literal `// Alpha:` comment prefix
    so future Alpha fields can use the same convention without API
    churn when they graduate.

  - `SnapRadius` (`int` meters, max 1000000). Sorts candidates by road
    significance rather than air distance; the much larger cap reflects
    its drag-and-drop-on-zoomed-out-map use case documented by HERE.

  - `Course` (`float64` degrees, 0-359, schema "number/double") and
    `MinCourseDistance` (`int32` meters, capped server-side at 2000).
    `Course` is `float64`, not `int`, because the schema is double —
    bare `int` would silently truncate fractional headings.

  - `SideOfStreetHint` (`*SideOfStreetHint`). The schema models this as
    a single nested object containing lat, lng, and an embedded `match`
    enum, not as two parallel top-level fields. Mirror that: the new
    `SideOfStreetHint` type carries lat/lng plus a `Match` field of a
    new `SideOfStreetMatch` `string` enum (`always` / `onlyIfDivided`,
    default `onlyIfDivided` when omitted, matching the schema default).
    No `Coordinate` type or top-level `matchSideOfStreet` field is
    introduced.

Field comments mirror HERE's postmatrix schema verbatim where it
matters — units, ranges, "Cannot be combined with ..." phrasing scoped
to what each property's own description states (so e.g. `Radius` lists
only `SnapRadius`, not `SideOfStreetHint`, since the schema only
excludes `SnapRadius` from `Radius`).

Cover the JSON wire format with a `CalculateMatrixBody` marshaling
test that walks each hint family in isolation: bare coords (no hints
emitted), `Radius`+`RadiusPenalty`, `SnapRadius`,
`Course`+`MinCourseDistance`, and a `SideOfStreetHint` with embedded
`Match`. The expected JSON for the side-of-street case nests `match`
inside `sideOfStreetHint`, mirroring the schema. Capturing `tt := tt`
in the loop silences a loopclosure vet warning Go 1.21 raises once the
table grew past two cases.

Relevant HERE docs:

https://docs.here.com/routing/reference/postmatrix
https://docs.here.com/routing/reference/calculateroutespost#user-content-supported-place-options
